### PR TITLE
allow pass extra settings for portiacrawl close #63

### DIFF
--- a/slybot/bin/portiacrawl
+++ b/slybot/bin/portiacrawl
@@ -13,7 +13,7 @@ def main():
     parser.add_option("-s", help="Add extra scrapy settings", dest="extra_settings", action="append", default=[], metavar="NAME=VALUE")
     parser.add_option("--output", "-o", help='dump scraped items into FILE (use - for stdout)', metavar='FILE')
     parser.add_option("--output-format", "-t", metavar='FORMAT', help='format to use for dumping items with -o (default: jsonlines)')
-    parser.add_option("--verbose", "-v", action="store_true", default=True, help="more verbose")
+    parser.add_option("--verbose", "-v", action="store_true", default=False, help="more verbose")
 
     opts, args = parser.parse_args()
 


### PR DESCRIPTION
now besides add setting to `slyd/slyd/settings.py`, portiacrawl also allow user adding extra settings from command line. e.g. `slybot/bin/portiacrawl -v slyd/data/projects/new_project/ www.yelp.co.uk -a start_urls=http://www.yelp.co.uk/biz/barrafina-london -s DEPTH_LIMIT=1`
