### PR TITLE
added python-dateparser as dependency for python-slybot

### DIFF
--- a/slybot/debian/control
+++ b/slybot/debian/control
@@ -12,7 +12,8 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, ${python:Depends},
  scrapy-0.18 | scrapy-0.20 | scrapy-0.22 | scrapy-0.24 | scrapy-0.25,
  python-scrapely,
  python-loginform,
- python-lxml
+ python-lxml,
+ python-dateparser
 Description: A web crawler implemented in Python.
  Slybot is a Python web crawler for doing web scraping. It's implemented on top
  of the Scrapy web crawling framework and the Scrapely extraction library.


### PR DESCRIPTION
Tested in cislave01.dev. Package builds correctly.

```$ dpkg -I ../python-slybot_0.11.1-r1129+201506022356~185531c_all.deb``` 
```
 Package: python-slybot
 Version: 0.11.1-r1129+201506022356~185531c
 Architecture: all
 Maintainer: Scrapinghub Team <info@scrapinghub.com>
 Installed-Size: 136
 Depends: python (>= 2.5), python-support (>= 0.90.0), scrapy-0.18 | scrapy-0.20 | scrapy-0.22 | scrapy-0.24 | scrapy-0.25, python-scrapely, python-loginform, python-lxml, python-dateparser
 Section: python
```