### PR TITLE
Develop

### DIFF
--- a/slyd/app/components/pin-toolbox-button.js
+++ b/slyd/app/components/pin-toolbox-button.js
@@ -11,12 +11,13 @@ export default BsButton.extend({
     }.property('toolbox.fixed'),
 
     pinned: function() {
-        return this.disabled || this.get('toolbox.pinned');
+        return this.get('disabled') || this.get('toolbox.pinned');
     }.property('toolbox.fixed', 'toolbox.pinned'),
 
     click: function() {
         this.set('toolbox.pinned', !this.get('toolbox.pinned'));
-        this.set('pinned', this.get('toolbox.pinned'));
-        this.notifyPropertyChange('pinned');
+        if(window.localStorage) {
+            localStorage.portia_toolbox_pinned = this.get('toolbox.pinned') ? 'true' : '';
+        }
     },
 });

--- a/slyd/app/components/tool-box.js
+++ b/slyd/app/components/tool-box.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
+    classNameBindings: ['fixed:toolbox-fixed'],
+
     documentView: function() {
         this.set('documentView', this.get('document.view'));
     }.property('document.view'),
@@ -23,47 +25,27 @@ export default Ember.Component.extend({
         }
     }.observes('fixed'),
 
-    timeoutHandle: null,
-
-    showToolbox: function() {
-        if (this.get('timeoutHandle')) {
-            Ember.run.cancel(this.get('timeoutHandle'));
-            this.set('timeoutHandle', null);
+    setToolboxNow: function(show){
+        if (!show && this.get('control.fixed')) {
+            return;
         }
-        var timeoutHandle = Ember.run.later(function() {
-            var self = this;
-            Ember.$('#toolbox').css('margin-right', 0);
-            Ember.$('#scraped-doc').css('margin-right', 400);
-            Ember.run.later(function() {
-                if (self.get && self.get('documentView') &&
-                      self.get('documentView').redrawNow) {
-                    self.get('documentView').redrawNow();
-                }
-            }, 320);
-        }.bind(this), 300);
-        this.set('timeoutHandle', timeoutHandle);
-    },
+        Ember.$('#toolbox').css('margin-right', show ? 0 : -365);
+        Ember.$('#scraped-doc').css('margin-right', show ? 400 : 35);
 
-    hideToolbox: function() {
-        if (this.get('timeoutHandle')) {
-            Ember.run.cancel(this.get('timeoutHandle'));
-            this.set('timeoutHandle', null);
-        }
-        var timeoutHandle = Ember.run.later(function() {
-            var self = this;
-            if (!this.get('control.fixed')) {
-                Ember.$('#toolbox').css('margin-right', -365);
-                Ember.$('#scraped-doc').css('margin-right', 35);
-                Ember.run.later(function() {
-                    if (self.get && self.get('documentView') &&
-                          self.get('documentView').redrawNow) {
-                        self.get('documentView').redrawNow();
-                    }
-                }, 820);
+        Ember.run.later(this, function(){
+            var docView = this.get('documentView');
+            if(docView && docView.redrawNow) {
+                docView.redrawNow();
             }
-        }.bind(this), 800);
-        this.set('timeoutHandle', timeoutHandle);
+        }, show ? 320 : 820);
     },
+
+    setToolbox: function(show) {
+        Ember.run.debounce(this, this.setToolboxNow, show, show ? 300 : 800);
+    },
+
+    showToolbox: function(){ return this.setToolbox(true); },
+    hideToolbox: function() { return this.setToolbox(false); },
 
     mouseEnter: function() {
         this.showToolbox();

--- a/slyd/app/initializers/toolbox.js
+++ b/slyd/app/initializers/toolbox.js
@@ -4,7 +4,7 @@ export function initialize(container, application) {
     container.register('toolbox:state', Ember.Object.create({
         fixed: false,
         expand: false,
-        pinned: false,
+        pinned: !!(window.localStorage && localStorage.portia_toolbox_pinned),
     }), { instantiate: false });
     application.inject('route', 'toolbox', 'toolbox:state');
     application.inject('component:tool-box', 'control', 'toolbox:state');

--- a/slyd/app/mixins/toolbox-state-mixin.js
+++ b/slyd/app/mixins/toolbox-state-mixin.js
@@ -2,6 +2,6 @@ import Ember from 'ember';
 
 export default Ember.Mixin.create({
     willEnter: function() {
-        this.set('toolbox.fixed', this.get('toolboxFixed') || false);
+        this.set('toolbox.fixed', this.get('fixedToolbox') || false);
     }
 });

--- a/slyd/app/styles/app.css
+++ b/slyd/app/styles/app.css
@@ -10,7 +10,7 @@ body{
 #scraped-doc {
     top: 38px;
     position:relative;
-    margin-right: 30px;
+    margin-right: 400px;
     transition: margin-right 0.3s ease-out;
 }
 
@@ -27,7 +27,7 @@ body{
     margin-top:35px;
     float: right;
     width: 400px;
-    margin-right: -365px;
+    margin-right: 0px;
     height: 100%;
     min-height: 200px;
     z-index: 100;
@@ -163,6 +163,10 @@ body{
 #toolbox .section {
     margin:10px 0px 10px 5px;
     overflow-x: hidden;
+}
+
+.toolbox-fixed .fa-thumb-tack, .toolbox-fixed .arrow-left {
+    display: none;
 }
 
 .scrolling-container {


### PR DESCRIPTION
Improvements to the toolbox:
* Remember the pinned state of the toolbox using localStorage.
* Start with the toolbox open (if it's pinned, it doesn't waste time with unnecessary animation, if unpinned if gives the user visual feedback of where are the controls).
* Hide thumbtack if the toolbox is fixed, since it doesn't perform any action.