### PR TITLE
Field name validation refactor

### DIFF
--- a/slybot/docs/project.rst
+++ b/slybot/docs/project.rst
@@ -82,7 +82,7 @@ name : string
 
 version : string
   Version number of the format.
-  
+
 comment : string : optional
   A comment provided by the user.
 
@@ -112,6 +112,10 @@ system, i.e: person, job, category, etc.::
     },
 
 Attributes:
+
+displayName: string : optional
+  User-friendly name of the item. If not specified, the item id will be used
+  instead.
 
 fields : mapping
   This is a mapping of the field names to the field objects representing

--- a/slybot/docs/project.rst
+++ b/slybot/docs/project.rst
@@ -113,7 +113,7 @@ system, i.e: person, job, category, etc.::
 
 Attributes:
 
-displayName: string : optional
+display_name: string : optional
   User-friendly name of the item. If not specified, the item id will be used
   instead.
 

--- a/slybot/slybot/validation/schemas.json
+++ b/slybot/slybot/validation/schemas.json
@@ -19,7 +19,7 @@
         "type": "object",
         "properties": {
             "fields": {"additionalProperties": {"$ref": "field"}, "required": true},
-            "displayName": {"type": "string", "required": false}
+            "display_name": {"type": "string", "required": false}
         }
     },
     {

--- a/slybot/slybot/validation/schemas.json
+++ b/slybot/slybot/validation/schemas.json
@@ -18,7 +18,8 @@
         "id": "item",
         "type": "object",
         "properties": {
-            "fields": {"additionalProperties": {"$ref": "field"}, "required": true}
+            "fields": {"additionalProperties": {"$ref": "field"}, "required": true},
+            "displayName": {"type": "string", "required": false}
         }
     },
     {

--- a/slyd/app/components/annotations-plugin/component.js
+++ b/slyd/app/components/annotations-plugin/component.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 import GuessTypes from '../../mixins/guess-types';
+import { validateFieldName } from 'portia-web/components/edit-item';
+import NotificationManager from 'portia-web/utils/notification-manager';
 
 // TODO: Add ids to name fields. Allow for names to be changed later.
 
@@ -842,6 +844,11 @@ export default Ember.Component.extend(GuessTypes, {
         var fieldName = this.get('newFieldName'),
             fieldType = this.get('newFieldType'),
             attrIndex = this.get('createNewIndex');
+
+        var error = validateFieldName(fieldName, this.getWithDefault('item.fields', []));
+        if(error) {
+            return NotificationManager.showWarningNotification('Validation Error', error);
+        }
         if (fieldName && fieldName.length > 0 && fieldType) {
             this.set('newFieldType', null);
             this.set('newFieldName', null);

--- a/slyd/app/components/bs-notifications.js
+++ b/slyd/app/components/bs-notifications.js
@@ -31,7 +31,9 @@ var NotificationsView = Ember.CollectionView.extend({
         fadeOut: function() {
             var _this = this;
             clearTimeout(this.get('timeoutId'));
-            return this.$().animate({ opacity: 0 }, this.get('fadeOutTime'), function() {
+            return this.$()
+              .stop()
+              .animate({ opacity: 0 }, this.get('fadeOutTime'), function() {
                 _this.$().slideUp(_this.get('fadeOutTime'), function() {
                     _this.get('parentView.content').removeObject(_this.get('content'));
                 });

--- a/slyd/app/components/edit-item.js
+++ b/slyd/app/components/edit-item.js
@@ -42,7 +42,7 @@ export default Ember.Component.extend(NotificationHandler, {
         },
 
         validateItemName: function(input){
-            if (this.get('items').findBy('name', input.text)) {
+            if (this.get('items').findBy('displayName', input.text)) {
                 input.setInvalid('There is already a item with that name.');
             }
         }

--- a/slyd/app/components/edit-item.js
+++ b/slyd/app/components/edit-item.js
@@ -2,11 +2,11 @@ import Ember from 'ember';
 import NotificationHandler from '../mixins/notification-handler';
 
 export function validateFieldName(name, fields) {
-    // Ensuring that field names start with a letter prevents overwriting
-    // _item, _template and any future "protected" property we might
-    // add to extracted items.
-    if (!/^[a-z]/i.test(name)) {
-        return 'Field names must start with a letter';
+    // Ensuring that field names don't start with underscores prevents
+    // overwriting _item, _template and any future "protected" property
+    // we might add to extracted items.
+    if (/^_/.test(name)) {
+        return "Field can't start with underscores";
     } else if (name === 'url') {
         return 'Naming a field "url" is not allowed as there is already a field with this name';
     } else if (fields.findBy('name', name)) {

--- a/slyd/app/components/edit-item.js
+++ b/slyd/app/components/edit-item.js
@@ -26,13 +26,19 @@ export default Ember.Component.extend(NotificationHandler, {
         },
 
         editField: function(text, index) {
-            if (text === 'url') {
+            // Ensuring that field names start with a letter prevents overwriting
+            // _item, _template and any future "protected" property we might
+            // add to extracted items.
+            if (text === 'url' || !/^[a-z]/i.test(text)) {
                 var field = this.get('item.fields').get(index);
                 if (field) {
                     field.set('name', this.get('itemFields').get(index).name);
                     this.get('item.fields').replace(index, 1, [field]);
                 }
-                this.showErrorNotification('Naming a field "url" is not allowed as there is already a field with this name');
+                this.showErrorNotification(text === 'url' ?
+                    'Naming a field "url" is not allowed as there is already a field with this name' :
+                    'Field names must start with a letter'
+                );
                 return;
             }
             this.updateFields();

--- a/slyd/app/components/edit-item.js
+++ b/slyd/app/components/edit-item.js
@@ -42,7 +42,7 @@ export default Ember.Component.extend(NotificationHandler, {
         },
 
         validateItemName: function(input){
-            if (this.get('items').findBy('displayName', input.text)) {
+            if (this.get('items').findBy('display_name', input.text)) {
                 input.setInvalid('There is already a item with that name.');
             }
         }

--- a/slyd/app/components/edit-item.js
+++ b/slyd/app/components/edit-item.js
@@ -26,22 +26,30 @@ export default Ember.Component.extend(NotificationHandler, {
         },
 
         editField: function(text, index) {
+            var error = null;
+
             // Ensuring that field names start with a letter prevents overwriting
             // _item, _template and any future "protected" property we might
             // add to extracted items.
-            if (text === 'url' || !/^[a-z]/i.test(text)) {
+            if (!/^[a-z]/i.test(text)) {
+                error = 'Field names must start with a letter';
+            } else if (text === 'url') {
+                error = 'Naming a field "url" is not allowed as there is already a field with this name';
+            } else if (this.get('item.fields').findBy('name', text)) {
+                error = 'There is alrready a field with that name.';
+            }
+
+            if(error) {
+                // Reset name to it's original value
                 var field = this.get('item.fields').get(index);
                 if (field) {
                     field.set('name', this.get('itemFields').get(index).name);
                     this.get('item.fields').replace(index, 1, [field]);
                 }
-                this.showErrorNotification(text === 'url' ?
-                    'Naming a field "url" is not allowed as there is already a field with this name' :
-                    'Field names must start with a letter'
-                );
-                return;
+                this.showErrorNotification(error);
+            } else {
+                this.updateFields();
             }
-            this.updateFields();
         }
     }
 });

--- a/slyd/app/components/edit-item.js
+++ b/slyd/app/components/edit-item.js
@@ -3,52 +3,40 @@ import NotificationHandler from '../mixins/notification-handler';
 
 export default Ember.Component.extend(NotificationHandler, {
     item: null,
-    itemFields: null,
+    items: null,
     extractionTypes: [],
-
-    updateFields: function() {
-        this.set('itemFields', (this.getWithDefault('item.fields', []) || []).copy());
-    }.on('init'),
 
     actions: {
         addField: function() {
             this.sendAction('addField', this.get('item'));
-            this.updateFields();
         },
 
         deleteField: function(field) {
             this.sendAction('deleteField', this.get('item'), field);
-            this.updateFields();
         },
 
         delete: function() {
             this.sendAction('delete', this.get('item'));
         },
 
-        editField: function(text, index) {
-            var error = null;
+        validateFieldName: function(input) {
+            var text = input.text;
 
             // Ensuring that field names start with a letter prevents overwriting
             // _item, _template and any future "protected" property we might
             // add to extracted items.
             if (!/^[a-z]/i.test(text)) {
-                error = 'Field names must start with a letter';
+                return input.setInvalid('Field names must start with a letter');
             } else if (text === 'url') {
-                error = 'Naming a field "url" is not allowed as there is already a field with this name';
+                return input.setInvalid('Naming a field "url" is not allowed as there is already a field with this name');
             } else if (this.get('item.fields').findBy('name', text)) {
-                error = 'There is alrready a field with that name.';
+                return input.setInvalid('There is already a field with that name.');
             }
+        },
 
-            if(error) {
-                // Reset name to it's original value
-                var field = this.get('item.fields').get(index);
-                if (field) {
-                    field.set('name', this.get('itemFields').get(index).name);
-                    this.get('item.fields').replace(index, 1, [field]);
-                }
-                this.showErrorNotification(error);
-            } else {
-                this.updateFields();
+        validateItemName: function(input){
+            if (this.get('items').findBy('name', input.text)) {
+                input.setInvalid('There is already a item with that name.');
             }
         }
     }

--- a/slyd/app/components/edit-item.js
+++ b/slyd/app/components/edit-item.js
@@ -1,10 +1,25 @@
 import Ember from 'ember';
 import NotificationHandler from '../mixins/notification-handler';
 
+export function validateFieldName(name, fields) {
+    // Ensuring that field names start with a letter prevents overwriting
+    // _item, _template and any future "protected" property we might
+    // add to extracted items.
+    if (!/^[a-z]/i.test(name)) {
+        return 'Field names must start with a letter';
+    } else if (name === 'url') {
+        return 'Naming a field "url" is not allowed as there is already a field with this name';
+    } else if (fields.findBy('name', name)) {
+        return 'There is already a field with that name.';
+    }
+    return null; // No error
+}
+
 export default Ember.Component.extend(NotificationHandler, {
     item: null,
     items: null,
     extractionTypes: [],
+
 
     actions: {
         addField: function() {
@@ -19,18 +34,10 @@ export default Ember.Component.extend(NotificationHandler, {
             this.sendAction('delete', this.get('item'));
         },
 
-        validateFieldName: function(input) {
-            var text = input.text;
-
-            // Ensuring that field names start with a letter prevents overwriting
-            // _item, _template and any future "protected" property we might
-            // add to extracted items.
-            if (!/^[a-z]/i.test(text)) {
-                return input.setInvalid('Field names must start with a letter');
-            } else if (text === 'url') {
-                return input.setInvalid('Naming a field "url" is not allowed as there is already a field with this name');
-            } else if (this.get('item.fields').findBy('name', text)) {
-                return input.setInvalid('There is already a field with that name.');
+        validateFieldName: function(input){
+            var error = validateFieldName(input.text, this.get('item.fields'));
+            if(error) {
+                input.setInvalid(error);
             }
         },
 

--- a/slyd/app/components/inline-editable-text-field.js
+++ b/slyd/app/components/inline-editable-text-field.js
@@ -28,14 +28,23 @@ export default Ember.Component.extend(NotificationHandler, {
                 return;
             }
             if (text !== this.get('text')) {
+                var error = null;
+                this.sendAction('validate', {
+                    text: text,
+                    setInvalid: (err) => error = err
+                });
+
                 var re = new RegExp(this.get('validation'), 'g');
-                if (re.test(text)) {
+                if (!error && !re.test(text)) {
+                    error = '"' + text + '" is not a valid name. Names must match "' + this.get('validation') +'".';
+                }
+
+                if(error) {
+                    this.set('editing', true);
+                    this.showWarningNotification('Validation Error', error);
+                } else {
                     this.set('text', text);
                     this.sendAction('action', this.get('text'), this.get('name'));
-                } else {
-                    this.showWarningNotification('Validation Error',
-                        '"' + text + '" is not a valid name. Names must match "' + this.get('validation') +'".');
-                    this.set('editing', true);
                 }
             }
         }

--- a/slyd/app/components/item-select.js
+++ b/slyd/app/components/item-select.js
@@ -35,10 +35,7 @@ export default Ember.Component.extend({
         var seenSelected = false,
             arr = defaultValue.concat(this.get('options').map(function(opt) {
                 if (typeof(opt) === 'string') {
-                    opt = {
-                        value: opt,
-                        label: opt,
-                    };
+                    opt = { value: opt };
                 } else if (opt instanceof Ember.Object) {
                     opt = {
                         value: opt.get(valueProperty),
@@ -47,12 +44,13 @@ export default Ember.Component.extend({
                 } else {
                     opt = {
                         value: opt[valueProperty] || opt.value,
-                        label: opt[labelProperty] || opt.label || opt.value,
+                        label: opt[labelProperty] || opt.label,
                     };
                 }
                 if (opt.value === selectedValue) {
                     seenSelected = true;
                 }
+                opt.label = opt.label || opt.value;
                 opt.selected = opt.value === selectedValue;
                 return opt;
             }));

--- a/slyd/app/components/item-select.js
+++ b/slyd/app/components/item-select.js
@@ -24,6 +24,8 @@ export default Ember.Component.extend({
 
     buildOptions: function() {
         var selectedValue = this.get('value'),
+            labelProperty = this.getWithDefault('labelProperty', 'name'),
+            valueProperty = this.getWithDefault('valueProperty', 'name'),
             defaultValue = [];
         if (!selectedValue) {
             defaultValue = [{value:'', label: '', selected: true}];
@@ -33,18 +35,26 @@ export default Ember.Component.extend({
         var seenSelected = false,
             arr = defaultValue.concat(this.get('options').map(function(opt) {
                 if (typeof(opt) === 'string') {
-                    opt = {value: opt};
+                    opt = {
+                        value: opt,
+                        label: opt,
+                    };
                 } else if (opt instanceof Ember.Object) {
-                    opt = {value: opt.get('name')};
+                    opt = {
+                        value: opt.get(valueProperty),
+                        label: opt.get(labelProperty),
+                    };
+                } else {
+                    opt = {
+                        value: opt[valueProperty] || opt.value,
+                        label: opt[labelProperty] || opt.label || opt.value,
+                    };
                 }
                 if (opt.value === selectedValue) {
                     seenSelected = true;
                 }
-                return {
-                    value: opt.value,
-                    label: opt.label || opt.value,
-                    selected: opt.value === selectedValue
-                };
+                opt.selected = opt.value === selectedValue;
+                return opt;
             }));
         if (!seenSelected && selectedValue && this.get('addSelected')) {
             arr.push({

--- a/slyd/app/controllers/items.js
+++ b/slyd/app/controllers/items.js
@@ -11,7 +11,7 @@ export default BaseController.extend({
     addItem: function() {
         var newItem = Item.create({
             name: this.shortGuid('_'),
-            displayName: 'New Item'
+            display_name: 'New Item'
         });
         this.addField(newItem);
         this.model.pushObject(newItem);

--- a/slyd/app/controllers/items.js
+++ b/slyd/app/controllers/items.js
@@ -9,7 +9,10 @@ export default BaseController.extend({
     documentView: null,
 
     addItem: function() {
-        var newItem = Item.create({ name: this.shortGuid('_') });
+        var newItem = Item.create({
+            name: this.shortGuid('_'),
+            displayName: 'New Item'
+        });
         this.addField(newItem);
         this.model.pushObject(newItem);
     },

--- a/slyd/app/controllers/template.js
+++ b/slyd/app/controllers/template.js
@@ -76,13 +76,14 @@ export default BaseController.extend({
     scrapedItem: function() {
         if (!Ember.isEmpty(this.get('items'))) {
             var item = this.get('items').findBy('name', this.get('model.scrapes'));
-            if (!item.fields) {
-                item.fields = [];
+            if(item) {
+                if (!item.fields) {
+                    item.fields = [];
+                }
+                return item;
             }
-            return item;
-        } else {
-            return null;
         }
+        return null;
     }.property('model.scrapes', 'items.@each'),
 
     displayExtractors: function() {

--- a/slyd/app/controllers/template.js
+++ b/slyd/app/controllers/template.js
@@ -498,7 +498,7 @@ export default BaseController.extend({
             });
             var item = Item.create({
                 name: this.get('model.scrapes'),
-                displayName: this.get('model.name'),
+                display_name: this.get('model.name'),
                 fields: []
             });
             fields.forEach((fieldName) => item.addField(fieldName));

--- a/slyd/app/mixins/notification-handler.js
+++ b/slyd/app/mixins/notification-handler.js
@@ -2,29 +2,8 @@ import Ember from 'ember';
 import NotificationManager from '../utils/notification-manager';
 
 export default Ember.Mixin.create({
-    showNotification: function(title, message, type) {
-        if (title && !message) {
-            message = title;
-            title = null;
-        }
-        if (message) {
-            NotificationManager.add({
-                title: title,
-                message: message,
-                type: type || 'info'
-            });
-        }
-    },
-
-    showSuccessNotification: function(title, message) {
-        this.showNotification(title, message, 'success');
-    },
-
-    showWarningNotification: function(title, message) {
-        this.showNotification(title, message, 'warning');
-    },
-
-    showErrorNotification: function(title, message) {
-        this.showNotification(title, message, 'danger');
-    }
+    showNotification: NotificationManager.showNotification.bind(NotificationManager),
+    showSuccessNotification: NotificationManager.showSuccessNotification.bind(NotificationManager),
+    showWarningNotification: NotificationManager.showWarningNotification.bind(NotificationManager),
+    showErrorNotification: NotificationManager.showErrorNotification.bind(NotificationManager),
 });

--- a/slyd/app/models/item.js
+++ b/slyd/app/models/item.js
@@ -3,7 +3,7 @@ import ItemField from './item-field';
 
 export default SimpleModel.extend({
     serializedRelations: ['fields'],
-    serializedProperties: ['name', 'displayName'],
+    serializedProperties: ['name', 'display_name'],
     fields: null,
 
     validateName: function(name) {

--- a/slyd/app/models/item.js
+++ b/slyd/app/models/item.js
@@ -3,7 +3,7 @@ import ItemField from './item-field';
 
 export default SimpleModel.extend({
     serializedRelations: ['fields'],
-    serializedProperties: ['name'],
+    serializedProperties: ['name', 'displayName'],
     fields: null,
 
     validateName: function(name) {

--- a/slyd/app/templates/components/edit-item.hbs
+++ b/slyd/app/templates/components/edit-item.hbs
@@ -1,7 +1,7 @@
 <div class="editable-item-container">
     <div>
         <span style="margin:2px 0px 0px 10px">
-            {{#inline-editable-text-field text=item.name validation='^[a-zA-Z0-9_-]+$'}}
+            {{#inline-editable-text-field validate="validateItemName" text=item.name validation='^[a-zA-Z0-9_-]+$'}}
                 Item: {{item.name}}
             {{/inline-editable-text-field}}
         </span>
@@ -27,7 +27,7 @@
                     <div class="row" style="margin:0">
                         <div class="col-xs-4 top-div">
                             <div class="field-name">
-                                {{#inline-editable-text-field action="editField" text=field.name name=index validation='^[a-zA-Z0-9_-]+$'}}
+                                {{#inline-editable-text-field validate="validateFieldName" text=field.name validation='^[a-zA-Z0-9_-]+$'}}
                                     <span class="editable-name">{{field.name}}</span>
                                 {{/inline-editable-text-field}}
                             </div>

--- a/slyd/app/templates/components/edit-item.hbs
+++ b/slyd/app/templates/components/edit-item.hbs
@@ -1,8 +1,8 @@
 <div class="editable-item-container">
     <div>
         <span style="margin:2px 0px 0px 10px">
-            {{#inline-editable-text-field validate="validateItemName" text=item.name validation='^[a-zA-Z0-9_-]+$'}}
-                Item: {{item.name}}
+            {{#inline-editable-text-field validate="validateItemName" text=item.displayName validation='^[a-zA-Z0-9_-]+$'}}
+                Item: {{item.displayName}}
             {{/inline-editable-text-field}}
         </span>
         <span style="float:right">

--- a/slyd/app/templates/components/edit-item.hbs
+++ b/slyd/app/templates/components/edit-item.hbs
@@ -1,8 +1,8 @@
 <div class="editable-item-container">
     <div>
         <span style="margin:2px 0px 0px 10px">
-            {{#inline-editable-text-field validate="validateItemName" text=item.displayName validation='^[a-zA-Z0-9_-]+$'}}
-                Item: {{item.displayName}}
+            {{#inline-editable-text-field validate="validateItemName" text=item.display_name validation='^[a-zA-Z0-9_-]+$'}}
+                Item: {{item.display_name}}
             {{/inline-editable-text-field}}
         </span>
         <span style="float:right">

--- a/slyd/app/templates/items/toolbox.hbs
+++ b/slyd/app/templates/items/toolbox.hbs
@@ -3,7 +3,7 @@
 	<div>
 		<div class="scrolling-container" {{bind-attr style="full_box_style"}}>
 			{{#each item in model}}
-				{{edit-item item=item extractionTypes=extractionTypes addField='addField' deleteField='deleteField' delete='deleteItem'}}
+				{{edit-item item=item items=model extractionTypes=extractionTypes addField='addField' deleteField='deleteField' delete='deleteItem'}}
 		 	{{else}}
 		 		<h4>No items have been defined yet.</h4>
 		 	{{/each}}

--- a/slyd/app/templates/template/toolbox.hbs
+++ b/slyd/app/templates/template/toolbox.hbs
@@ -23,7 +23,7 @@
 
 	{{#accordion-item title="Extracted item"}}
 		<label class="small-label">Extracted item type:</label>
-		{{item-select options=items value=controller.scrapedItem.id changed='updateScraped'}}
+		{{item-select options=items labelProperty='displayName' value=controller.scrapedItem.id changed='updateScraped'}}
 		{{inline-help message="select_item"}}
 		<div style="margin-top:10px">
 			{{#bs-button clicked="editItems" type="primary" size="sm"}}

--- a/slyd/app/templates/template/toolbox.hbs
+++ b/slyd/app/templates/template/toolbox.hbs
@@ -23,7 +23,7 @@
 
 	{{#accordion-item title="Extracted item"}}
 		<label class="small-label">Extracted item type:</label>
-		{{item-select options=items labelProperty='displayName' value=controller.scrapedItem.id changed='updateScraped'}}
+		{{item-select options=items labelProperty='display_name' value=controller.scrapedItem.id changed='updateScraped'}}
 		{{inline-help message="select_item"}}
 		<div style="margin-top:10px">
 			{{#bs-button clicked="editItems" type="primary" size="sm"}}

--- a/slyd/app/utils/notification-manager.js
+++ b/slyd/app/utils/notification-manager.js
@@ -12,6 +12,32 @@ var NotificationManager = Ember.Object.create({
         */
         var notification = Ember.Object.create(options);
         return this.get('content').pushObject(notification);
+    },
+
+    showNotification: function(title, message, type) {
+        if (title && !message) {
+            message = title;
+            title = null;
+        }
+        if (message) {
+            this.add({
+                title: title,
+                message: message,
+                type: type || 'info'
+            });
+        }
+    },
+
+    showSuccessNotification: function(title, message) {
+        this.showNotification(title, message, 'success');
+    },
+
+    showWarningNotification: function(title, message) {
+        this.showNotification(title, message, 'warning');
+    },
+
+    showErrorNotification: function(title, message) {
+        this.showNotification(title, message, 'danger');
     }
 });
 

--- a/slyd/app/utils/slyd-api.js
+++ b/slyd/app/utils/slyd-api.js
@@ -403,6 +403,7 @@ export var SlydApi = Ember.Object.extend(ApplicationUtils, {
         return this.makeAjaxCall(hash).then(function(items) {
             items = this.dictToList(items, Item);
             items.forEach(function(item) {
+                item.displayName = item.displayName || item.name;
                 if (item.fields) {
                     item.fields = this.dictToList(item.fields, ItemField);
                 }

--- a/slyd/app/utils/slyd-api.js
+++ b/slyd/app/utils/slyd-api.js
@@ -403,7 +403,7 @@ export var SlydApi = Ember.Object.extend(ApplicationUtils, {
         return this.makeAjaxCall(hash).then(function(items) {
             items = this.dictToList(items, Item);
             items.forEach(function(item) {
-                item.displayName = item.displayName || item.name;
+                item.display_name = item.display_name || item.name;
                 if (item.fields) {
                     item.fields = this.dictToList(item.fields, ItemField);
                 }

--- a/slyd/tests/acceptance/edit-items-test.js
+++ b/slyd/tests/acceptance/edit-items-test.js
@@ -1,0 +1,84 @@
+import acceptanceTest from '../helpers/acceptance-test';
+import Ember from 'ember';
+import { lastRequest, fixtures } from '../helpers/fixtures';
+
+module('Acceptance | Edit Items', { });
+
+const save = 'button:contains("Save changes")';
+const add_item = 'button:contains("Item") .fa-plus';
+const inline_field = '.form-control.input-sm';
+
+var savedItems = null;
+
+fixtures['POST /projects/11/spec/items'] = function(items){
+    savedItems = items;
+};
+
+
+acceptanceTest('Edit Items', function(app, assert) {
+
+  var reset = () => visit('/projects/11/items');
+
+  function getItemNames (){
+      return Object.values(savedItems).map((item) => item.display_name).sort();
+  }
+
+  reset().then(function(){
+      lastRequest.clear();
+      return click(save);
+  }).then(function(){
+      var saveReq = lastRequest.captured.filter((req) => req.method === 'POST')[0];
+      equal(saveReq.url, '/projects/11/spec/items');
+      deepEqual(Object.keys(savedItems), ['default']);
+      return reset();
+  })
+  .then(() => click(add_item))
+  .then(() => click('.editable-name:contains("Item: New")'))
+  .then(() => fillIn(inline_field, 'foobar'))
+  .then(() => triggerEvent(inline_field, 'blur'))
+  .then(() => click(save)).then(function(){
+      deepEqual(getItemNames(), ['default_item', 'foobar']);
+      return reset();
+  })
+  .then(() => click('.editable-name:contains("optional")'))
+  .then(() => fillIn(inline_field, 'url'))
+  .then(() => triggerEvent(inline_field, 'blur')).then(function(){
+    ok($(inline_field).length, "Can't name a field 'url'");
+    ok(app.lastNotification.message, 'Shows a message explaining');
+    app.lastNotification = null;
+  })
+  .then(() => fillIn(inline_field, '_foobar'))
+  .then(() => triggerEvent(inline_field, 'blur')).then(function(){
+    ok($(inline_field).length, "Can't start a field with underscore");
+    ok(app.lastNotification.message, 'Shows a message explaining');
+    app.lastNotification = null;
+  })
+  .then(() => fillIn(inline_field, 'price'))
+  .then(() => triggerEvent(inline_field, 'blur')).then(function(){
+    ok($(inline_field).length, "Can't name two fields the same");
+    ok(app.lastNotification.message, 'Shows a message explaining');
+    app.lastNotification = null;
+  })
+  .then(() => fillIn(inline_field, 'foobar'))
+  .then(() => triggerEvent(inline_field, 'blur')).then(function(){
+    ok($(inline_field).length === 0, "Works when valid name");
+    ok(!app.lastNotification, "Doesn't show notification when valid name");
+    return click(save);
+  }).then(function(){
+      var fields = Ember.copy(fixtures['/projects/11/spec/items'].default.fields, true);
+      fields.foobar = fields.optional;
+      delete fields.optional;
+      deepEqual(savedItems.default.fields, fields);
+      return reset();
+  })
+  .then(() => click('.row:has(.editable-name:contains("optional")) .fa-trash:eq(0)'))
+  .then(() => click('.row:has(.editable-name:contains("price")) .fa-trash:eq(0)'))
+  .then(() => click(save))
+  .then(function(){
+      var fields = Ember.copy(fixtures['/projects/11/spec/items'].default.fields, true);
+      delete fields.optional;
+      delete fields.price;
+      deepEqual(savedItems.default.fields, fields);
+  });
+});
+

--- a/slyd/tests/acceptance/spider-test.js
+++ b/slyd/tests/acceptance/spider-test.js
@@ -43,4 +43,55 @@ acceptanceTest('List spiders', function(app, assert) {
   });
 });
 
+acceptanceTest('Initialization Panel', function(app, assert) {
+
+  function $initPanel(){
+    return find('.panel:eq(0)');
+  }
+
+  function getStartUrls(){
+    return $initPanel().find('.clickable-url button').map((i, elm) => $(elm).text().trim()).toArray();
+  }
+
+  visit('/projects/11/spider1').then(function(){
+    equal(currentURL(), '/projects/11/spider1');
+    equal(find('.nav-container .current-crumb').text().trim(), 'spider1');
+    deepEqual(getStartUrls(), ['http://portiatest.com']);
+    ok($initPanel().find('button .fa-plus').parent()[0].hasAttribute('disabled'), 'Add urls button should be disabled if textarea is empty');
+    return fillIn($initPanel().find('textarea'), '\nhttp://url1.com\n\nhttp://url2.com\n\n');
+  }).then(function(){
+    ok(!$initPanel().find('button .fa-plus').parent()[0].hasAttribute('disabled'), 'Add urls button should be enabled if user has types urls');
+    return click($initPanel().find('button .fa-plus'));
+  }).then(function(){
+    deepEqual(getStartUrls(), ['http://portiatest.com', 'http://url1.com', 'http://url2.com']);
+    equal(lastRequest.url, '/projects/11/spec/spiders/spider1');
+    deepEqual(lastRequest.data.start_urls, ['http://portiatest.com', 'http://url1.com', 'http://url2.com']);
+    return click($initPanel().find('.btn-danger .fa-trash').eq(1));
+  }).then(function(){
+    deepEqual(getStartUrls(), ['http://portiatest.com', 'http://url2.com']);
+    deepEqual(lastRequest.data.start_urls, ['http://portiatest.com', 'http://url2.com']);
+    return click($initPanel().find('.btn-danger .fa-trash').eq(0));
+  }).then(function(){
+    deepEqual(getStartUrls(), ['http://url2.com']);
+    deepEqual(lastRequest.data.start_urls, ['http://url2.com']);
+    return click($initPanel().find('button:contains("Edit All")'));
+  }).then(function(){
+    equal($initPanel().find('textarea').val().trim(), 'http://url2.com');
+    return fillIn($initPanel().find('textarea'), '\nhttp://portiatest.com\n\n');
+  }).then(function(){
+    return click($initPanel().find('button .fa-plus'));
+  }).then(function(){
+    deepEqual(getStartUrls(), ['http://portiatest.com']);
+    deepEqual(lastRequest.data.start_urls, ['http://portiatest.com']);
+    return click($initPanel().find('button:contains("Edit All")'));
+  }).then(function(){
+    equal($initPanel().find('textarea').val().trim(), 'http://portiatest.com');
+    return fillIn($initPanel().find('textarea'), 'http://asdasdasdad.com');
+  }).then(function(){
+    return click($initPanel().find('button:contains("cancel")'));
+  }).then(function(){
+    deepEqual(getStartUrls(), ['http://portiatest.com']);
+    deepEqual(lastRequest.data.start_urls, ['http://portiatest.com']);
+  });
+});
 

--- a/slyd/tests/helpers/acceptance-test.js
+++ b/slyd/tests/helpers/acceptance-test.js
@@ -2,11 +2,22 @@ import Ember from 'ember';
 import startApp from 'portia-web/tests/helpers/start-app';
 import WebDocument from 'portia-web/components/web-document';
 import { Canvas } from 'portia-web/utils/canvas';
+import { lastRequest } from '../helpers/fixtures';
+
+import NotificationManager from 'portia-web/utils/notification-manager';
 
 export default function portiaTest(name, fn) {
     test(name, function(assert) {
+        lastRequest.clear();
         var root = $('<div/>').appendTo(document.body);
         var canvas = $('<canvas/>').attr('id', 'testCanvas_' + Date.now()).appendTo(document.body);
+
+        NotificationManager.reopen({
+            add: function(obj){
+                app.lastNotification = obj;
+            }
+        });
+
         var app = startApp({
             rootElement: root[0],
             LOG_TRANSITIONS: true, // basic logging of successful transitions

--- a/slyd/tests/helpers/acceptance-test.js
+++ b/slyd/tests/helpers/acceptance-test.js
@@ -1,10 +1,12 @@
 import Ember from 'ember';
 import startApp from 'portia-web/tests/helpers/start-app';
 import WebDocument from 'portia-web/components/web-document';
+import { Canvas } from 'portia-web/utils/canvas';
 
 export default function portiaTest(name, fn) {
     test(name, function(assert) {
         var root = $('<div/>').appendTo(document.body);
+        var canvas = $('<canvas/>').attr('id', 'testCanvas_' + Date.now()).appendTo(document.body);
         var app = startApp({
             rootElement: root[0],
             LOG_TRANSITIONS: true, // basic logging of successful transitions
@@ -15,11 +17,17 @@ export default function portiaTest(name, fn) {
             app.setupForTesting();
             app.injectTestHelpers();
             var doc = app.registry.resolve('document:obj');
-            WebDocument.create({document: doc});
+            WebDocument.create({
+                document: doc,
+                canvas: Canvas.create({
+                    canvasId: canvas.attr('id')
+                })
+            });
             fn.call(that, app, assert);
             andThen(function() {
                 app.destroy();
                 root.remove();
+                canvas.remove();
             });
         });
     });

--- a/slyd/tests/helpers/fixtures.js
+++ b/slyd/tests/helpers/fixtures.js
@@ -48,6 +48,43 @@ fixtures['/projects/11/spec/spiders/spider1'] = {
     "templates": []
 };
 
+fixtures['/projects/11/spec/items'] = {
+    "default": {
+        "fields": {
+            "required": {
+                "required": true,
+                "type": "text",
+                "vary": false
+            },
+            "optional": {
+                "required": false,
+                "type": "text",
+                "vary": false
+            },
+            "image": {
+                "required": false,
+                "type": "image",
+                "vary": false
+            },
+            "text": {
+                "required": false,
+                "type": "text",
+                "vary": false
+            },
+            "price": {
+                "required": true,
+                "type": "price",
+                "vary": false
+            },
+            "safe_html": {
+                "required": true,
+                "type": "safe html",
+                "vary": false
+            }
+        }
+    }
+};
+
 fixtures['POST /projects'] = function(data) {
     var pid = data.args[0];
     if(data.cmd === 'conflicts'){
@@ -59,6 +96,8 @@ fixtures['POST /projects'] = function(data) {
     }
     console.log('POST command without fixture', JSON.stringify(data));
 };
+
+fixtures['POST /projects/11/spec/spiders/spider1'] = Ember.$.noop;
 
 export var lastRequest = {
     method: null,
@@ -77,7 +116,7 @@ Ember.$.ajax = function(args){
     } else if (args.type === 'POST' && ('POST ' + url) in fixtures) {
         args.success(fixtures['POST ' + url](data), 'sucess', {});
     } else {
-        console.log('Undefined fixture', args.type, url);
+        console.log('Undefined fixture: ' + args.type + ' ' + url + (data ? ' ' + JSON.stringify(data) : ''));
         args.success({}, 'sucess', {});
     }
 };

--- a/slyd/tests/helpers/fixtures.js
+++ b/slyd/tests/helpers/fixtures.js
@@ -1,7 +1,7 @@
 import config from 'portia-web/config/environment';
 import Ember from 'ember';
 
-var fixtures = {};
+export var fixtures = {};
 
 fixtures['/server_capabilities'] = {
     "capabilities": {
@@ -50,6 +50,7 @@ fixtures['/projects/11/spec/spiders/spider1'] = {
 
 fixtures['/projects/11/spec/items'] = {
     "default": {
+        "display_name": "default_item",
         "fields": {
             "required": {
                 "required": true,
@@ -102,19 +103,33 @@ fixtures['POST /projects/11/spec/spiders/spider1'] = Ember.$.noop;
 export var lastRequest = {
     method: null,
     url: null,
-    data: null
+    data: null,
+    captured: [],
+
+    clear: function(){
+        this.url = null;
+        this.method = null;
+        this.data = null;
+        this.captured = [];
+    },
+    add: function(url, method, data){
+        this.url = url;
+        this.method = method;
+        this.data = data;
+        this.captured.push({url, method, data});
+    }
 };
 
 Ember.$.ajax = function(args){
     var url = args.url.replace(/^https?:\/\/[^\/]+/, '');
     var data = args.data && JSON.parse(args.data);
-    lastRequest.method = args.type;
-    lastRequest.url = url;
-    lastRequest.data = data;
+    lastRequest.add(url, args.type, data);
     if(args.type === 'GET' && url in fixtures) {
-        args.success(fixtures[url], 'sucess', {});
+        args.success(Ember.copy(fixtures[url], true), 'sucess', {});
     } else if (args.type === 'POST' && ('POST ' + url) in fixtures) {
-        args.success(fixtures['POST ' + url](data), 'sucess', {});
+        var response = fixtures['POST ' + url](data) || {};
+        response = Ember.copy(response, true);
+        args.success(response, 'sucess', {});
     } else {
         console.log('Undefined fixture: ' + args.type + ' ' + url + (data ? ' ' + JSON.stringify(data) : ''));
         args.success({}, 'sucess', {});


### PR DESCRIPTION
Refactor validations:
- Show an error message when adding a duplicated field
- Show an error message when adding a field that doesn't start with a letter (to prevent overwriting _item and _template)
- Show an error when changing an item name if there is already a item with that name.
- Validate field names when creating them in the annotation editor too.

Also on this pull request:
- Added one test
- Fixed a couple sentry issues