### PR TITLE
Fix broken pages with malformed tag names, toggleCSS and duplicate template names

### DIFF
--- a/slyd/app/components/bs-button.js
+++ b/slyd/app/components/bs-button.js
@@ -8,8 +8,6 @@ export default Ember.Component.extend(Popover, {
 
   tagName: 'button',
   classNameBindings: ['class'],
-  activeType: null,
-  inactiveType: null,
   processing: false,
 
   attributeBindings: ['disabled', 'title', 'width'],
@@ -32,15 +30,6 @@ export default Ember.Component.extend(Popover, {
   }.observes('activeType'),
 
   click: function() {
-    if (this.get('activeType')) {
-      if (!this.get('inactiveType')) {
-        this.set('inactiveType', this.get('activeType'));
-        this.set('activeType', this.getWithDefault('type', 'default'));
-      }
-      var tmp = this.get('activeType');
-      this.set('activeType', this.get('inactiveType'));
-      this.set('inactiveType', tmp);
-    }
     return this.sendAction('clicked', this.get('clickedParam'));
   }
 });

--- a/slyd/app/components/web-document-js/component.js
+++ b/slyd/app/components/web-document-js/component.js
@@ -59,17 +59,21 @@ function treeMirrorDelegate(){
             var node = null;
             if(tagName === 'SCRIPT' || tagName === 'META' || tagName === 'BASE') {
                 node = document.createElement('NOSCRIPT');
-            } else if(tagName === 'FORM') {
-                node = document.createElement(tagName);
+            } else {
+                try {
+                    node = document.createElement(tagName);
+                } catch(e) {
+                    // Invalid tag name
+                    node = document.createElement('NOSCRIPT');
+                }
+            }
+            if(tagName === 'FORM') {
                 $(node).on('submit', ()=>false);
             } else if (tagName === 'IFRAME' || tagName === 'FRAME') {
-                node = document.createElement(tagName);
                 node.setAttribute('src', '/static/frames-not-supported.html');
             } else if (tagName === 'CANVAS') {
-                node = document.createElement(tagName);
                 paintCanvasMessage(node);
             } else if (tagName === 'OBJECT' || tagName === 'EMBED') {
-                node = document.createElement(tagName);
                 setTimeout(addEmbedBlockedMessage.bind(null, node), 100);
             }
             return node;

--- a/slyd/app/components/web-document-js/component.js
+++ b/slyd/app/components/web-document-js/component.js
@@ -180,8 +180,8 @@ export default WebDocument.extend({
     },
 
     _wsOpenChange: function(){
-        this.setInteractionsBlocked(this.get('ws.opened'), 'ws');
-    }.observes('ws.opened'),
+        this.setInteractionsBlocked(this.get('ws.closed'), 'ws');
+    }.observes('ws.closed'),
 
     /**
      * Set the content of the iframe. Can only be called in "select" mode

--- a/slyd/app/components/web-document-js/component.js
+++ b/slyd/app/components/web-document-js/component.js
@@ -188,12 +188,9 @@ export default WebDocument.extend({
      */
     setIframeContent: function(doc) {
         this.assertInMode('select');
-        var iframe = Ember.$('#' + this.get('iframeId'));
-        iframe.attr('srcdoc', doc);
-        // Wait until iframe has fully loaded before setting iframe to the current iframe
-        iframe.load(function() {
-            this.set('document.iframe', iframe);
-        }.bind(this));
+        var iframe = this.getIframeNode();
+        iframe.setAttribute('srcdoc', doc);
+        this.set('cssEnabled', true);
     },
 
     clearIframe: function() {

--- a/slyd/app/components/web-document.js
+++ b/slyd/app/components/web-document.js
@@ -40,7 +40,7 @@ export default Ember.Component.extend({
 
     loadingDoc: false,
 
-    cssEnabled: true,
+    cssEnabled: true, // Only in "select" mode
 
     redrawSprites: function() {
         this.redrawNow();
@@ -60,7 +60,8 @@ export default Ember.Component.extend({
     */
     config: function(options) {
         this.set('listener', options.listener);
-        if(options.mode) {
+        if(options.mode && options.mode !== this.get('mode')) {
+            this.set('cssEnabled', true);
             this.set('mode', options.mode);
         }
         if (options.mode === 'select') {
@@ -235,7 +236,7 @@ export default Ember.Component.extend({
     toggleCSS: function() {
         this.assertInMode('select');
         var iframe = this.getIframe();
-        if (this.cssEnabled) {
+        if (this.get('cssEnabled')) {
             iframe.find('link[rel="stylesheet"]').each(function() {
                 Ember.$(this).renameAttr('href', '_href');
             });
@@ -259,7 +260,7 @@ export default Ember.Component.extend({
             });
         }
         this.redrawNow();
-        this.cssEnabled = !this.cssEnabled;
+        this.toggleProperty('cssEnabled');
     },
 
     /**
@@ -332,6 +333,7 @@ export default Ember.Component.extend({
         var iframe = this.getIframe();
         iframe.find('html').html(contents);
         this.set('document.iframe', iframe);
+        this.set('cssEnabled', true);
     },
 
     _updateHoveredInfoVisibility: function() {

--- a/slyd/app/components/web-document.js
+++ b/slyd/app/components/web-document.js
@@ -327,15 +327,6 @@ export default Ember.Component.extend({
         return iframe.documentElement && iframe.documentElement.outerHTML;
     },
 
-    setIframeContent: function(contents) {
-        this.assertInMode('select');
-
-        var iframe = this.getIframe();
-        iframe.find('html').html(contents);
-        this.set('document.iframe', iframe);
-        this.set('cssEnabled', true);
-    },
-
     _updateHoveredInfoVisibility: function() {
         var display = this.get('mode') === 'select' ? 'inline': 'none';
         Ember.$("#hovered-element-info").css('display', display);

--- a/slyd/app/controllers/spider.js
+++ b/slyd/app/controllers/spider.js
@@ -11,6 +11,10 @@ export default BaseController.extend({
 
     needs: ['application', 'projects', 'project', 'project/index'],
 
+    queryParams: ['url', 'baseurl'],
+    url: null,
+    baseurl: null,
+
     saving: false,
 
     browseHistory: [], // List of urls
@@ -565,6 +569,11 @@ export default BaseController.extend({
             mode: 'browse',
             listener: this,
         });
+        if(this.get('url')) {
+            this.loadUrl(this.get('url'), this.get('baseurl'));
+            this.set('url', null);
+            this.set('baseurl', null);
+        }
     },
 
     willLeave: function() {

--- a/slyd/app/controllers/spider.js
+++ b/slyd/app/controllers/spider.js
@@ -216,13 +216,20 @@ export default BaseController.extend({
     },
 
     addTemplate: function() {
-        var iframeTitle = this.get('documentView').getIframe()[0].title;
+        let iframeTitle = (this.get('documentView').getIframe()[0].title
+            .trim()
+            .replace(/[^a-z\s_-]/ig, '')
+            .replace(/\s+/g, '_')
+            .substring(0, 48)
+            .replace(/_+$/, '') || utils.shortGuid());
 
-        var template_name = iframeTitle.trim().replace(/[^a-z\s_-]/ig, '')
-                                       .replace(/\s+/g, '_').substring(0, 48);
-        if (!template_name) {
-            template_name = utils.shortGuid();
+        // Find an unique template name
+        let template_name = iframeTitle;
+        let template_num = 1;
+        while(this.get('model.template_names').contains(template_name)) {
+            template_name = iframeTitle + '_' + (template_num++);
         }
+
         var template = Template.create({
             name: template_name,
             extractors: {},

--- a/slyd/app/controllers/spider/index.js
+++ b/slyd/app/controllers/spider/index.js
@@ -1,44 +1,5 @@
-import Ember from 'ember';
 import BaseController from '../base-controller';
-import SpriteStore from '../../utils/sprite-store';
 
 export default BaseController.extend({
-    queryParams: ['url', 'baseurl', 'rmt'],
-    needs: ['spider'],
-    url: null,
-    baseurl: null,
-    rmt: null,
-
-    fetchQueryUrl: function() {
-        if(this.get('url')) {
-            var url = this.url, baseurl = this.baseurl;
-            this.set('url', null);
-            this.set('baseurl', null);
-            Ember.run.next(this, function() {
-                this.get('controllers.spider').loadUrl(url, baseurl);
-            });
-        }
-    }.observes('url'),
-
-    removeTemplate: function() {
-        if (this.get('rmt')) {
-            this.get('controllers.spider.model.template_names').removeObject(this.get('rmt'));
-            this.set('rmt', null);
-        }
-    }.observes('rmt'),
-
     _breadCrumb: null,
-
-    willEnter: function() {
-        this.get('documentView').config({
-            mode: 'browse',
-            listener: this,
-        });
-    },
-
-    willLeave: function() {
-        this.set('documentView.sprites', new SpriteStore());
-        this.get('documentView').hideLoading();
-        this.get('documentView.ws').send({'_command': 'close_tab'});
-    },
 });

--- a/slyd/app/controllers/template.js
+++ b/slyd/app/controllers/template.js
@@ -417,14 +417,10 @@ export default BaseController.extend({
         discardChanges: function() {
             var hasData = false, tools = this.get('extractionTools'),
                 finishDiscard = function() {
-                    var params = {
-                        url: this.get('model.url')
-                    };
-                    if (!hasData) {
-                        params.rmt = this.get('model.name');
-                    }
                     this.transitionToRoute('spider', {
-                        queryParams: params
+                        queryParams: {
+                            url: this.get('model.url')
+                        }
                     });
                 }.bind(this);
             this.set('documentView.sprites', new SpriteStore());
@@ -438,8 +434,12 @@ export default BaseController.extend({
             if (hasData) {
                 finishDiscard();
             } else {
-                this.get('slyd').deleteTemplate(this.get('slyd.spider'),
-                                                this.get('model.name')).then(finishDiscard);
+                this.get('slyd')
+                    .deleteTemplate(this.get('slyd.spider'), this.get('model.name'))
+                    .then(() => {
+                        this.get('controllers.spider.model.template_names').removeObject(this.get('model.name'));
+                    })
+                    .then(finishDiscard);
             }
         },
 

--- a/slyd/app/initializers/register-api.js
+++ b/slyd/app/initializers/register-api.js
@@ -2,7 +2,6 @@ import Ember from 'ember';
 import ajax from 'ic-ajax';
 import config from '../config/environment';
 import SlydApi from '../utils/slyd-api';
-import Timer from '../utils/timer';
 import utils from '../utils/utils';
 
 

--- a/slyd/app/templates/template/topbar.hbs
+++ b/slyd/app/templates/template/topbar.hbs
@@ -18,7 +18,7 @@
 			{{/bs-button}}
 		{{/if}}
 		{{#if showToggleCSS}}
-			{{#bs-button clicked="toggleCSS" icon="fa fa-icon fa-file-code-o" activeType="danger" size="sm" title="Toggle CSS"}}
+			{{#bs-button clicked="toggleCSS" icon="fa fa-icon fa-file-code-o" classNameBindings="documentView.cssEnabled::btn-danger" size="sm" title="Toggle CSS"}}
 				CSS
 			{{/bs-button}}
 		{{/if}}

--- a/slyd/app/utils/ferry-websocket.js
+++ b/slyd/app/utils/ferry-websocket.js
@@ -64,6 +64,14 @@ export default Ember.Object.extend({
         this.set('closed', true);
         this.set('connecting', false);
         Ember.Logger.log('<Closed Websocket>');
+
+        let closeError = new Error('Socket disconnected');
+        let deferreds = this.get('deferreds');
+        for(var deferred of Object.keys(deferreds)) {
+            deferreds[deferred].reject(closeError);
+            delete deferreds[deferred];
+        }
+
         if(e.code !== APPLICATION_UNLOADING_CODE && e.code !== 1000) {
             var timeout = this._connectTimeout();
             this.set('secondsUntilReconnect', Math.round(timeout/1000));

--- a/slyd/tests/test_bot.py
+++ b/slyd/tests/test_bot.py
@@ -43,7 +43,6 @@ class BotTest(unittest.TestCase):
         value = json.loads(result.value())
         # expect 200 response and base href added
         self.assertEqual(value['response']['status'], 200)
-        self.assertIn('<base href="%s"' % test_url, value['page'])
 
         # parse fetched data
         test_url = "http://localhost:8997/pin1.html"


### PR DESCRIPTION
- Fix broken pages with malformed tag names like `<imgsrc="image.png"/>`. Also indirectly fixes some of the "No node with id \d+" errors.
- Make sure template names are unique
- Reset the state of cssEnabled when changing modes, read the state from documentView