### PR TITLE
Update splash version to last night's dev version

### DIFF
--- a/slyd/requirements.txt
+++ b/slyd/requirements.txt
@@ -4,10 +4,13 @@ service_identity==14.0.0
 requests==2.7.0
 autobahn==0.10.4
 six==1.5.2
-splash==1.6
 chardet==2.3.0
 monotonic==0.3
 
 # Dulwich's MySQL backend
 --allow-external=mysql-connector-python
 https://github.com/scrapinghub/dulwich/tarball/420a056#egg=dulwich
+
+# Splash dev
+--allow-external=splash
+https://github.com/scrapinghub/splash/archive/3acde4ef0d389e5067d51dcc9b4ac6d260658757.tar.gz


### PR DESCRIPTION
This commit fixed an issue that has been reported independently at least 4 times:
https://github.com/scrapinghub/splash/commit/d0c752cf3b340c6c381f5f35ac048aa86f2ca988

Use splash master branch until next splash stable version is released.