### PR TITLE
Update installation.rst

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -52,7 +52,7 @@ Running Portia Locally
 
 Install the following dependencies::
 
-    sudo apt-get install libxml2-dev libxslt-dev python-dev zlib1g-dev libffi-dev libssl-dev
+    sudo apt-get install libxml2-dev libxslt-dev python-dev zlib1g-dev libffi-dev libssl-dev libjpeg-dev
 
 If you would like to run Portia locally you should create an environment with virtualenv::
 


### PR DESCRIPTION
Somewhere in 2015 a requirement for a certain https://python-pillow.github.io/ version made it so that the development headers for jpeg are also needed. This was tested on ubuntu 14.04 raspberry pi 2 model B. Error log will be up for a month http://pastebin.com/R1S17NCk
