### PR TITLE
Automatic links

### DIFF
--- a/slybot/requirements.txt
+++ b/slybot/requirements.txt
@@ -7,3 +7,4 @@ dateparser==0.2
 jsonschema==2.4.0
 six==1.5.2
 scrapyjs==0.1.1
+page_finder==0.1

--- a/slybot/requirements.txt
+++ b/slybot/requirements.txt
@@ -7,4 +7,4 @@ dateparser==0.2
 jsonschema==2.4.0
 six==1.5.2
 scrapyjs==0.1.1
-page_finder==0.1
+page_finder==0.1.1

--- a/slybot/setup.py
+++ b/slybot/setup.py
@@ -2,7 +2,7 @@ from slybot import __version__
 from setuptools import setup, find_packages
 
 install_requires = ['Scrapy', 'scrapely', 'loginform', 'lxml', 'jsonschema',
-                    'dateparser', 'scrapyjs']
+                    'dateparser', 'scrapyjs', 'page_finder']
 extras = {
     'tests': ['nose']
 }

--- a/slybot/slybot/linkextractor/__init__.py
+++ b/slybot/slybot/linkextractor/__init__.py
@@ -5,6 +5,7 @@ from scrapy.utils.misc import load_object
 
 from .base import BaseLinkExtractor, ALLOWED_SCHEMES
 from .html import HtmlLinkExtractor
+from .pagination import PaginationExtractor
 from .xml import XmlLinkExtractor, RssLinkExtractor, SitemapLinkExtractor, AtomLinkExtractor
 from .regex import RegexLinkExtractor
 from .ecsv import CsvLinkExtractor
@@ -15,6 +16,7 @@ _TYPE_MAP = (
     ('xpath', XmlLinkExtractor, False),
     ('column', CsvLinkExtractor, False),
     ('html', HtmlLinkExtractor, True),
+    ('pagination', PaginationExtractor, True),
     ('rss', RssLinkExtractor, True),
     ('sitemap', SitemapLinkExtractor, True),
     ('atom', AtomLinkExtractor, True),

--- a/slybot/slybot/linkextractor/pagination.py
+++ b/slybot/slybot/linkextractor/pagination.py
@@ -1,0 +1,27 @@
+from page_finder import LinkAnnotation
+from .html import HtmlLinkExtractor
+
+
+class PaginationExtractor(HtmlLinkExtractor):
+    def __init__(self):
+        self.link_annotation = LinkAnnotation()
+        self.visited = set()
+        super(PaginationExtractor, self).__init__()
+
+    def _extract_links(self, response):
+        self.visited.add(response.url)
+        url_to_link = {
+            url: link
+            for link in super(PaginationExtractor, self)._extract_links(response)
+        }
+        self.link_annotation.load(url_to_link)
+        n_items = response.meta.get('n_items')
+        if pagination is not None:
+            self.link_annotation.mark_link(response.url, follow=(n_items > 0))
+        best = self.link_annotation.best_links_to_follow()
+        if best:
+            for url in best:
+                if url not in self.visited:
+                    return url_to_link[url] # TODO: extract only the best link?
+        else:
+            return url_to_link.values()

--- a/slybot/slybot/linkextractor/pagination.py
+++ b/slybot/slybot/linkextractor/pagination.py
@@ -11,12 +11,12 @@ class PaginationExtractor(HtmlLinkExtractor):
     def _extract_links(self, response):
         self.visited.add(response.url)
         url_to_link = {
-            url: link
+            link.url: link
             for link in super(PaginationExtractor, self)._extract_links(response)
         }
         self.link_annotation.load(url_to_link)
         n_items = response.meta.get('n_items')
-        if pagination is not None:
+        if n_items is not None:
             self.link_annotation.mark_link(response.url, follow=(n_items > 0))
         best = self.link_annotation.best_links_to_follow()
         if best:

--- a/slybot/slybot/linkextractor/pagination.py
+++ b/slybot/slybot/linkextractor/pagination.py
@@ -1,3 +1,5 @@
+from scrapy.http import Response
+
 from page_finder import LinkAnnotation
 from .html import HtmlLinkExtractor
 
@@ -8,20 +10,24 @@ class PaginationExtractor(HtmlLinkExtractor):
         self.visited = set()
         super(PaginationExtractor, self).__init__()
 
-    def _extract_links(self, response):
-        self.visited.add(response.url)
+    def _extract_links(self, response_or_htmlpage):
+        self.visited.add(response_or_htmlpage.url)
         url_to_link = {
             link.url: link
-            for link in super(PaginationExtractor, self)._extract_links(response)
+            for link in super(PaginationExtractor, self)._extract_links(response_or_htmlpage)
         }
         self.link_annotation.load(url_to_link)
-        n_items = response.meta.get('n_items')
+        if isinstance(response_or_htmlpage, Response):
+            n_items = response_or_htmlpage.meta.get('n_items')
+        else:
+            n_items = response_or_htmlpage.headers.get('n_items')
         if n_items is not None:
-            self.link_annotation.mark_link(response.url, follow=(n_items > 0))
+            self.link_annotation.mark_link(
+                response_or_htmlpage.url, follow=(n_items > 0))
         best = self.link_annotation.best_links_to_follow()
         if best:
             for url in best:
                 if url not in self.visited:
-                    return url_to_link[url] # TODO: extract only the best link?
+                    return [url_to_link[url]] # TODO: extract only the best link?
         else:
             return url_to_link.values()

--- a/slybot/slybot/plugins/scrapely_annotations/annotations.py
+++ b/slybot/slybot/plugins/scrapely_annotations/annotations.py
@@ -95,6 +95,7 @@ class Annotations(object):
     def handle_html(self, response, seen=None):
         htmlpage = htmlpage_from_response(response)
         items, link_regions = self.extract_items(htmlpage)
+        htmlpage.headers['n_items'] = len(items)
         for item in items:
             yield item
         for request in self._process_link_regions(htmlpage, link_regions):

--- a/slybot/slybot/plugins/scrapely_annotations/annotations.py
+++ b/slybot/slybot/plugins/scrapely_annotations/annotations.py
@@ -11,7 +11,7 @@ from scrapely.extraction import InstanceBasedLearningExtractor
 from scrapely.htmlpage import HtmlPage, dict_to_page
 
 from slybot.linkextractor import (HtmlLinkExtractor, SitemapLinkExtractor,
-                                  RssLinkExtractor,)
+                                  PaginationExtractor, )
 from slybot.linkextractor import create_linkextractor_from_specs
 from slybot.item import SlybotItem, create_slybot_item_descriptor
 from slybot.extractors import apply_extractors
@@ -56,7 +56,10 @@ class Annotations(object):
         ), key=lambda pair: pair[0])
 
         self.itemcls_info = {}
-        self.html_link_extractor = HtmlLinkExtractor()
+        if settings.get('AUTO_PAGINATION'):
+            self.html_link_extractor = PaginationExtractor()
+        else:
+            self.html_link_extractor = HtmlLinkExtractor()
         for itemclass_name, triplets in groupby(_item_template_pages,
                                                 itemgetter(0)):
             page_extractors_pairs = map(itemgetter(1, 2), triplets)

--- a/slybot/slybot/plugins/scrapely_annotations/annotations.py
+++ b/slybot/slybot/plugins/scrapely_annotations/annotations.py
@@ -95,7 +95,7 @@ class Annotations(object):
     def handle_html(self, response, seen=None):
         htmlpage = htmlpage_from_response(response)
         items, link_regions = self.extract_items(htmlpage)
-        htmlpage.headers['n_items'] = len(items)
+        response.meta['n_items'] = htmlpage.headers['n_items'] = len(items)
         for item in items:
             yield item
         for request in self._process_link_regions(htmlpage, link_regions):

--- a/slybot/slybot/plugins/scrapely_annotations/annotations.py
+++ b/slybot/slybot/plugins/scrapely_annotations/annotations.py
@@ -95,7 +95,11 @@ class Annotations(object):
     def handle_html(self, response, seen=None):
         htmlpage = htmlpage_from_response(response)
         items, link_regions = self.extract_items(htmlpage)
-        response.meta['n_items'] = htmlpage.headers['n_items'] = len(items)
+        htmlpage.headers['n_items'] = len(items)
+        try:
+            response.meta['n_items'] = len(items)
+        except AttributeError:
+            pass # response not tied to any request
         for item in items:
             yield item
         for request in self._process_link_regions(htmlpage, link_regions):

--- a/slybot/slybot/tests/test_linkextractors.py
+++ b/slybot/slybot/tests/test_linkextractors.py
@@ -1,10 +1,9 @@
 from unittest import TestCase
 from scrapy.http import TextResponse, HtmlResponse
-
+from slybot.utils import htmlpage_from_response
 from slybot.linkextractor import (
         create_linkextractor_from_specs,
-        RssLinkExtractor,
-        SitemapLinkExtractor,
+
 )
 
 class Test_RegexLinkExtractor(TestCase):
@@ -211,3 +210,15 @@ class Test_HtmlLinkExtractor(TestCase):
         self.assertEqual(links[0].url, 'http://www.example.com/path')
         self.assertEqual(links[0].text, 'Click here')
 
+
+class Test_PaginationExtractor(TestCase):
+    def test_simple(self):
+        specs = {"type": "pagination", "value": None}
+        lextractor = create_linkextractor_from_specs(specs)
+        html_page = htmlpage_from_response(
+            HtmlResponse(url='http://www.example.com/', body=html))
+        html_page.headers['n_items'] = 1
+        links = list(lextractor.links_to_follow(html_page))
+        self.assertEqual(len(links), 1)
+        self.assertEqual(links[0].url, 'http://www.example.com/path')
+        self.assertEqual(links[0].text, 'Click here')

--- a/slybot/slybot/validation/schema.py
+++ b/slybot/slybot/validation/schema.py
@@ -93,6 +93,17 @@ def get_schema_validator(schema):
                 return False
         return True
 
+    # Workaround for https://github.com/Julian/jsonschema/pull/272
+    @FormatChecker.cls_checks('regex', (Exception))
+    def is_valid_re(re_source):
+        if not isinstance(re_source, six.string_types):
+            return False
+        if isinstance(re_source, six.binary_type):
+            re_source = re_source.decode('utf-8')
+
+        re.compile(re_source)
+        return True
+
     return SlybotJsonSchemaValidator(_SCHEMAS[schema], resolver=resolver,
                                      format_checker=FormatChecker())
 

--- a/slybot/slybot/validation/schemas.json
+++ b/slybot/slybot/validation/schemas.json
@@ -18,7 +18,7 @@
         "id": "item",
         "type": "object",
         "properties": {
-            "fields": {"additionalProperties": {"$ref": "field"}, "required": true},
+            "fields": {"type": "object", "additionalProperties": {"$ref": "field"}, "required": true},
             "display_name": {"type": "string", "required": false}
         }
     },

--- a/slyd/app/templates/spider/toolbox.hbs
+++ b/slyd/app/templates/spider/toolbox.hbs
@@ -1,7 +1,7 @@
 
 <div style="text-align:center;font-size:1.1em;margin:10px 0px 10px 0px">
     {{#if capabilities.rename_spiders}}
-        {{#inline-editable-text-field text=model.name validation='^[a-zA-Z0-9_-\.]+$' name=model.name action='rename'}}
+        {{#inline-editable-text-field text=model.name validation='^[a-zA-Z0-9_\.-]+$' name=model.name action='rename'}}
             Spider: {{model.name}}
         {{/inline-editable-text-field}}
     {{else}}

--- a/slyd/app/utils/ferry-websocket.js
+++ b/slyd/app/utils/ferry-websocket.js
@@ -123,7 +123,7 @@ export default Ember.Object.extend({
                 }
             }
             if (data.error) {
-                NotificationManager.showErrorNotification(data.reason || data.error);
+                NotificationManager.showErrorNotification(data.reason || data.error, data.message);
                 console.error(data.reason || data.error);
             }else if (command in this.get('commands')) {
                 this.get('commands')[command](data);

--- a/slyd/dist/assets/portia-web-10aafa3f812e9d1f7505f50c8e6a3126.js
+++ b/slyd/dist/assets/portia-web-10aafa3f812e9d1f7505f50c8e6a3126.js
@@ -19895,7 +19895,7 @@ define('portia-web/templates/spider/toolbox', ['exports'], function (exports) {
           var morph0 = dom.createMorphAt(fragment,0,0,contextualElement);
           dom.insertBoundary(fragment, null);
           dom.insertBoundary(fragment, 0);
-          block(env, morph0, context, "inline-editable-text-field", [], {"text": get(env, context, "model.name"), "validation": "^[a-zA-Z0-9_-\\.]+$", "name": get(env, context, "model.name"), "action": "rename"}, child0, null);
+          block(env, morph0, context, "inline-editable-text-field", [], {"text": get(env, context, "model.name"), "validation": "^[a-zA-Z0-9_\\.-]+$", "name": get(env, context, "model.name"), "action": "rename"}, child0, null);
           return fragment;
         }
       };

--- a/slyd/dist/index.html
+++ b/slyd/dist/index.html
@@ -19,7 +19,7 @@
     
 
     <script src="assets/vendor-dfc2f09645d0591fcddf9411517048e0.js"></script>
-    <script src="assets/portia-web-138635d671c58615081ee61aa527bc2c.js"></script>
+    <script src="assets/portia-web-10aafa3f812e9d1f7505f50c8e6a3126.js"></script>
 
     
   </body>

--- a/slyd/slyd/gitstorage/jsondiff.py
+++ b/slyd/slyd/gitstorage/jsondiff.py
@@ -68,7 +68,7 @@ class Conflict(object):
                 new_other.append(next(i_other))
             elif diff.startswith('+'):
                 new_mine.append(next(i_mine))
-            else:
+            elif diff.startswith(' '):
                 next(i_other)
                 result.append(next(i_mine))
         return result

--- a/slyd/slyd/projecttemplates.py
+++ b/slyd/slyd/projecttemplates.py
@@ -59,7 +59,7 @@ default = slybot.settings
 
 _ITEMS_TEMPLATE = """\
 {
-    "default": {}
+    "default": {"fields": {}}
 }
 """
 

--- a/slyd/slyd/splash/commands.py
+++ b/slyd/slyd/splash/commands.py
@@ -165,7 +165,6 @@ _valid_params = {
 def log_event(data, socket):
     event = data.get('event')
     param = data.get('param')
-    print 'le', event, param
 
     if event not in _valid_params or param not in _valid_params[event]:
         return
@@ -176,7 +175,6 @@ def log_event(data, socket):
                 'command': '%s.%s' % (event, param)}
     msg = (u'Stat: id=%(session)s t=%(session_time)s '
            u'user=%(user)s command=%(command)s' % (msg_data))
-    print msg
     log.err(msg)
 
 
@@ -235,15 +233,8 @@ class ProjectData(ProjectModifier):
         except BaseWSError as ex:
             print(('Other: %s' % ex))
             raise ex
-        except Exception as ex:
-            # XXX: Catch any other errors and log them leaving Websocket open
-            log.err(traceback.format_exc(ex))
         else:
-            try:
-                spec.savejson(obj, [s.encode('utf-8') for s in path])
-            except Exception as ex:
-                # XXX: Catch errors in saving to the backend
-                log.err(traceback.format_exc(ex))
+            spec.savejson(obj, [s.encode('utf-8') for s in path])
             socket.update_spider(meta, **{type: obj})
             return obj
 

--- a/slyd/slyd/splash/ferry.py
+++ b/slyd/slyd/splash/ferry.py
@@ -228,23 +228,24 @@ class FerryServerProtocol(WebSocketServerProtocol):
             except Exception as e:
                 command = data.get('_callback') or command
                 if isinstance(e, BaseHTTPError):
-                    code = e.status
-                    reason = e.title
+                    code, reason, message = e.status, e.title, e.body
                 else:
                     code = 500
                     reason = "Internal Server Error"
+                    message = "An unexpected error has occurred."
 
-                failure = Failure(e)
+                failure = Failure()
                 log.err(failure)
                 event_id = getattr(failure, 'sentry_event_id', None)
                 if event_id:
-                    reason = "%s (Event ID: %s)" % (reason, event_id)
+                    message = "%s (Event ID: %s)" % (message, event_id)
 
                 return self.sendMessage({
                     'error': code,
                     '_command': command,
                     'id': data.get('_meta', {}).get('id'),
-                    'reason': reason
+                    'reason': reason,
+                    'message': message,
                 })
 
             if result:


### PR DESCRIPTION
Introduces the following changes into slybot:

- Adds dependency page_finder
- Spider will add a new header field `n_items` with the number of extracted items from the HTML page
- When the spider is run with `AUTO_PAGINATION=1` the two changes described above will make the spider to follow links detected as pagination links by page_finder