### PR TITLE
change wording and ordering in relationship dropdowns

### DIFF
--- a/portiaui/app/components/combo-box.js
+++ b/portiaui/app/components/combo-box.js
@@ -39,8 +39,13 @@ export default SelectBox.extend({
 
     updateViewValue() {
         const query = this.get('query');
-        const items = [];
+        let items = [];
         this.trigger('getMenuItems', items);
+
+        if (this.orderItemsForSearch) {
+            items = this.orderItemsForSearch(items);
+        }
+
         const currentValue = this.getValueAttribute(this.get('viewValue'));
         if (currentValue !== query) {
             let item = items.find(item => {

--- a/portiaui/app/components/dropdown-menu.js
+++ b/portiaui/app/components/dropdown-menu.js
@@ -1,18 +1,23 @@
 import Ember from 'ember';
 
 function computedItem(propertyName) {
-    const cachePropertyName = `_${propertyName}Cache`;
+    const cachePropertyName = `_${propertyName}ItemCache`;
 
     return Ember.computed(propertyName, 'items', {
         get() {
-            let cachedValue = this[cachePropertyName];
+            let cachedItem = this[cachePropertyName];
             const value = this.get(propertyName);
-            const items = this.get('items');
-            if (!cachedValue || !items.includes(cachedValue) ||
-                    cachedValue.get('value') !== value) {
-                this[cachePropertyName] = cachedValue = items.findBy('value', value);
+            let items = this.get('items');
+            if (!cachedItem || !items.includes(cachedItem) ||
+                    cachedItem.get('value') !== value) {
+                if (this.orderItemsForSearch) {
+                    items = this.orderItemsForSearch(items);
+                }
+                const equalityFn = this.valuesEqual || Ember.isEqual;
+                this[cachePropertyName] = cachedItem =
+                    items.find(item => equalityFn(item.get('value'), value));
             }
-            return cachedValue;
+            return cachedItem;
         },
 
         set(key, item) {
@@ -147,6 +152,14 @@ export default Ember.Component.extend({
         if (!this.get('isDestroying')) {
             this.notifyPropertyChange('items');
         }
+    },
+
+    orderItemsForSearch(items) {
+        return items;
+    },
+
+    valuesEqual(a, b) {
+        return Ember.isEqual(a, b);
     },
 
     actions: {

--- a/portiaui/app/components/list-item-relation-manager.js
+++ b/portiaui/app/components/list-item-relation-manager.js
@@ -8,6 +8,30 @@ export default Ember.Component.extend({
     selecting: false,
     value: null,
 
+    choicesOrdering: ['name'],
+    sortedChoices: Ember.computed.sort('choices', 'choicesOrdering'),
+
+    orderItemsForSearch(items) {
+        function sortPriority(item) {
+            switch (item.get('value.special')) {
+                case 'rename':
+                    return 1;
+                case 'add':
+                    return 2;
+                default:
+                    return 0;
+            }
+        }
+
+        return items.sort((a, b) => sortPriority(a) - sortPriority(b));
+    },
+
+    valuesEqual(a, b) {
+        const aValue = a && (a.get ? a.get('name') : a.name);
+        const bValue = b && (b.get ? b.get('name') : b.name);
+        return aValue === bValue;
+    },
+
     actions: {
         add(name) {
             if (typeof this.attrs.validate === 'function' && !this.attrs.validate(name)) {

--- a/portiaui/app/templates/components/combo-box.hbs
+++ b/portiaui/app/templates/components/combo-box.hbs
@@ -1,4 +1,4 @@
-{{#dropdown-widget class="combo-box" events=this open=(mut open) active=(mut viewValue) focused=value menuContainer=menuContainer menuClass=menuClass menuAlign=menuAlign onClose=(action 'menuClosed')  as |widget|}}
+{{#dropdown-widget class="combo-box" events=this open=(mut open) active=(mut viewValue) focused=value orderItemsForSearch=orderItemsForSearch valuesEqual=valuesEqual menuContainer=menuContainer menuClass=menuClass menuAlign=menuAlign onClose=(action 'menuClosed')  as |widget|}}
     {{#if (eq widget.section 'widget')}}
         <div class="combo-input">
             {{input id=inputId type="text" class=(concat "form-control dropdown-toggle " inputClass) value=query escape-press=(action widget.closeMenu 'escape') focus-in=(chain-actions widget.openMenu widget.focusIn) focus-out=(chain-actions widget.focusOut (action 'restoreFocus')) spellcheck=spellcheck}}

--- a/portiaui/app/templates/components/dropdown-widget.hbs
+++ b/portiaui/app/templates/components/dropdown-widget.hbs
@@ -1,5 +1,5 @@
 {{yield (hash section='widget' openMenu=(action 'openMenu') closeMenu=(action 'closeMenu') toggleMenu=(action 'toggleMenu') focusIn=(action 'focusIn') focusOut=(action 'focusOut') keyDown=(action 'keyDown'))}}
-{{#dropdown-menu class=menuClasses events=events keyNavigate=keyNavigate active=(mut active) focused=(mut focused) onFocusIn=(action 'focusIn') onFocusOut=(action 'focusOut') as |options|}}
+{{#dropdown-menu class=menuClasses events=events keyNavigate=keyNavigate active=(mut active) focused=(mut focused) orderItemsForSearch=orderItemsForSearch valuesEqual=valuesEqual onFocusIn=(action 'focusIn') onFocusOut=(action 'focusOut') as |options|}}
     {{#if open}}
         {{yield (hash section='menu' menu=options.menu header=options.header item=options.item divider=options.divider openMenu=(action 'openMenu') closeMenu=(action 'closeMenu') toggleMenu=(action 'toggleMenu') focusIn=(action 'focusIn') focusOut=(action 'focusOut') keyDown=(action 'keyDown'))}}
     {{/if}}

--- a/portiaui/app/templates/components/list-item-annotation-field.hbs
+++ b/portiaui/app/templates/components/list-item-annotation-field.hbs
@@ -1,11 +1,9 @@
 {{#list-item-relation-manager value=(mut annotation.field) choices=annotation.field.schema.fields selecting=(mut selecting) onChange=(action 'changeField') validate=(action 'validateFieldName') create=(action 'addField') as |options|}}
-    {{#if (eq options.section 'choices')}}
+    {{#if (eq options.section 'change-header')}}
+        Type to change the field
+    {{else if (eq options.section 'choices-header')}}
         Select an existing field
     {{else if (eq options.section 'choice')}}
         {{list-item-icon class="icon" icon=options.choice.type}}{{options.choice.name}}
-    {{else if (eq options.section 'rename')}}
-        Rename the selected field
-    {{else if (eq options.section 'add')}}
-        Add a new field to the data format
     {{/if}}
 {{/list-item-relation-manager}}

--- a/portiaui/app/templates/components/list-item-combo.hbs
+++ b/portiaui/app/templates/components/list-item-combo.hbs
@@ -1,10 +1,10 @@
 {{#if selecting}}
     {{#if hasBlock}}
-        {{#combo-box choices=choices value=(mut value) valueAttribute=valueAttribute open=(mut selecting) onChange=onChange autoSelect=autoSelect inputClass=(concat "input-list-item " inputClass) menuClass=menuClass menuAlign=menuAlign menuContainer=menuContainer as |options|}}
+        {{#combo-box choices=choices value=(mut value) valueAttribute=valueAttribute open=(mut selecting) orderItemsForSearch=orderItemsForSearch valuesEqual=valuesEqual onChange=onChange autoSelect=autoSelect inputClass=(concat "input-list-item " inputClass) menuClass=menuClass menuAlign=menuAlign menuContainer=menuContainer as |options|}}
             {{yield options}}
         {{/combo-box}}
     {{else}}
-        {{combo-box choices=choices value=(mut value) valueAttribute=valueAttribute open=(mut selecting) onChange=onChange autoSelect=autoSelect inputClass=(concat "input-list-item " inputClass) menuClass=menuClass menuAlign=menuAlign menuContainer=menuContainer}}
+        {{combo-box choices=choices value=(mut value) valueAttribute=valueAttribute open=(mut selecting) orderItemsForSearch=orderItemsForSearch valuesEqual=valuesEqual onChange=onChange autoSelect=autoSelect inputClass=(concat "input-list-item " inputClass) menuClass=menuClass menuAlign=menuAlign menuContainer=menuContainer}}
     {{/if}}
 {{else}}
     <span>

--- a/portiaui/app/templates/components/list-item-item-schema.hbs
+++ b/portiaui/app/templates/components/list-item-item-schema.hbs
@@ -1,11 +1,9 @@
 {{#list-item-relation-manager value=(mut item.schema) choices=item.sample.spider.project.schemas selecting=(mut selecting) onChange=(action 'changeSchema') create=(action 'addSchema') as |options|}}
-    {{#if (eq options.section 'choices')}}
+    {{#if (eq options.section 'change-header')}}
+        Type to change the data format
+    {{else if (eq options.section 'choices-header')}}
         Select an existing data format
     {{else if (eq options.section 'choice')}}
         {{list-item-icon class="icon" icon='schema'}}{{options.choice.name}}
-    {{else if (eq options.section 'rename')}}
-        Rename the selected data format
-    {{else if (eq options.section 'add')}}
-        Create a new data format
     {{/if}}
 {{/list-item-relation-manager}}

--- a/portiaui/app/templates/components/list-item-relation-manager.hbs
+++ b/portiaui/app/templates/components/list-item-relation-manager.hbs
@@ -1,23 +1,22 @@
-{{#list-item-combo value=(mut value.content) valueAttribute='name' selecting=(mut selecting) onChange=onChange autoSelect=true menuContainer="body" as |combo|}}
+{{#list-item-combo value=(mut value.content) valueAttribute='name' selecting=(mut selecting) orderItemsForSearch=orderItemsForSearch valuesEqual=valuesEqual onChange=onChange autoSelect=true menuContainer="body" as |combo|}}
     {{#combo.header}}
-        {{yield (hash section='choices')}}
+        {{yield (hash section='change-header')}}
     {{/combo.header}}
-    {{#each choices as |choice|}}
+    {{#combo.item value=(hash special="rename" name=combo.query onMenuClosed=(action 'rename' combo.query)) disabled=(not combo.menu.active.special) action=(chain-actions (action 'rename' combo.query) (action combo.closeMenu 'escape'))}}
+        {{list-item-icon class="icon" icon="edit"}}Rename to “{{combo.query}}”
+    {{/combo.item}}
+    {{#combo.item value=(hash special="add" name=combo.query onMenuClosed=(action 'add' combo.query)) disabled=(not combo.menu.active.special) action=(chain-actions (action 'add' combo.query) (action combo.closeMenu 'escape'))}}
+        {{list-item-icon class="icon" icon="add"}}Add “{{combo.query}}”
+    {{/combo.item}}
+
+    {{combo.divider}}
+
+    {{#combo.header}}
+        {{yield (hash section='choices-header')}}
+    {{/combo.header}}
+    {{#each sortedChoices as |choice|}}
         {{#combo.item value=choice action=(action combo.setValueAndClose choice)}}
             {{yield (hash section='choice' choice=choice)}}
         {{/combo.item}}
     {{/each}}
-    {{combo.divider}}
-    {{#combo.header}}
-        {{yield (hash section='rename')}}
-    {{/combo.header}}
-    {{#combo.item value=(hash special="rename" name=combo.query onMenuClosed=(action 'rename' combo.query)) disabled=(not combo.menu.active.special) action=(chain-actions (action 'rename' combo.query) (action combo.closeMenu 'escape'))}}
-        {{list-item-icon class="icon" icon="edit"}}Rename to {{combo.query}}
-    {{/combo.item}}
-    {{#combo.header}}
-        {{yield (hash section='add')}}
-    {{/combo.header}}
-    {{#combo.item value=(hash special="add" name=combo.query onMenuClosed=(action 'add' combo.query)) disabled=(not combo.menu.active.special) action=(chain-actions (action 'add' combo.query) (action combo.closeMenu 'escape'))}}
-        {{list-item-icon class="icon" icon="add"}}Add {{combo.query}}
-    {{/combo.item}}
 {{/list-item-combo}}


### PR DESCRIPTION
changed schema/field dropdown menus to improve discoverability of rename:
* mention typing
* rename at top
* also sort field/schema names alphabetically

![menu](https://cloud.githubusercontent.com/assets/9825131/13405132/45c87cc8-df1d-11e5-95d2-69ffd9bef86a.png)
