### PR TITLE
Fix patching of ported spider

### DIFF
--- a/slyd/slyd/resources/spiders.py
+++ b/slyd/slyd/resources/spiders.py
@@ -43,7 +43,7 @@ def update_spider(manager, spider_id, attributes):
     if rename:
         manager.rename_spider(spider_id, spider['name'].encode('utf-8'))
         spider_id = spider['name']
-        spider['id'] = spider_id
+    spider['id'] = spider_id
     clean_spider(spider)
     manager.savejson(spider, ['spiders', spider_id.encode('utf-8')])
     spider['samples'] = [{'id': name} for name in spider['template_names']]

--- a/slyd/slyd/utils/projects.py
+++ b/slyd/slyd/utils/projects.py
@@ -57,7 +57,7 @@ def clean_spider(obj):
         obj['start_urls'] = list(ODict([(x, 1) for x in obj['start_urls']]))
     # XXX: Need id to keep track of renames for deploy and export
     if 'id' not in obj:
-        obj['id'] = short_guid()
+        obj['id'] = obj.get('name') or short_guid()
 
 
 def add_plugin_data(obj, plugins):


### PR DESCRIPTION
Most spiders ported from old-portia have name=name and id=guid(),
if you update a spider property from new portia UI it will return a guid
as the spider id, subsequent requests will have the guid in the url
instead of the spider's name and will fail