### PR TITLE
don't allow sidebar to collapse on narrow screen widths

### DIFF
--- a/portiaui/app/styles/components/browser-view-port.scss
+++ b/portiaui/app/styles/components/browser-view-port.scss
@@ -1,6 +1,6 @@
 .browser-view-port {
     position: relative;
-    flex: 1 0 auto;
+    flex: 1 1 auto;
     display: flex;
     flex-direction: column;
     flex-wrap: nowrap;
@@ -36,34 +36,43 @@
     }
 }
 
+$panel-heading-vertical-padding: nth($panel-heading-padding, 1);
+$panel-heading-horizontal-padding: nth($panel-heading-padding, 2);
 .browser-navigation {
     flex: 0 0 auto;
     display: flex;
     flex-direction: row;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
     align-items: center;
+    justify-content: center;
+    padding: ($panel-heading-vertical-padding / 2) ($panel-heading-horizontal-padding / 2);
     z-index: 1;
 
     .btn {
         line-height: $line-height-computed;
     }
 
-    > * {
-        flex: 0 0 auto;
-        margin: 0 ($panel-body-padding / 2);
-
-        &:first-child {
-            margin-left: 0;
-        }
-
-        &:last-child {
-            margin-right: 0;
-        }
-    }
-
     .navbar-form {
         padding: 0;
         flex: 1 1 auto;
+    }
+
+    .browser-toolbar {
+        flex: 0 1 auto;
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: center;
+        margin: 0;
+    }
+}
+
+.browser-navigation,
+.browser-toolbar {
+    > * {
+        flex: 0 0 auto;
+        margin: ($panel-heading-vertical-padding / 2) ($panel-heading-horizontal-padding / 2);
     }
 }
 

--- a/portiaui/app/styles/components/side-bar.scss
+++ b/portiaui/app/styles/components/side-bar.scss
@@ -1,5 +1,6 @@
 #side-bar {
     width: $sidebar-width;
+    flex: 0 0 auto;
     background-color: $sidebar-background-color;
     border-right: 1px solid $navbar-default-border;
     padding: $navbar-padding-horizontal $navbar-padding-horizontal ($navbar-padding-horizontal + 10px);

--- a/portiaui/app/templates/components/browser-view-port.hbs
+++ b/portiaui/app/templates/components/browser-view-port.hbs
@@ -1,6 +1,8 @@
 <div class="browser-navigation panel-heading">
     {{url-bar class="navbar-form" role="navigation"}}
-    {{yield (hash section="toolbar")}}
+    <div class="browser-toolbar">
+        {{yield (hash section="toolbar")}}
+    </div>
 </div>
 <div class="browser-banner{{unless webSocket.closed ' hide'}}">
     {{#if webSocket.connecting}}


### PR DESCRIPTION
also wrap viewport toolbar on narrow screens.

this results in a layout like this on narrow screens:
![sidebar](https://cloud.githubusercontent.com/assets/9825131/14169287/2faa1416-f727-11e5-8a2a-5701dabed689.png)

and is a base for changes to the viewport layout.
layout optimizations for small screens will be addressed in a later PR