### PR TITLE
PORTIA-442: refactor adapter url generation

### DIFF
--- a/portiaui/app/adapters/annotation.js
+++ b/portiaui/app/adapters/annotation.js
@@ -1,6 +1,6 @@
 import SlydJSONAPIAdapter from '../utils/adapter';
 
 export default SlydJSONAPIAdapter.extend({
-    urlTemplate: '{+host}/api/projects/{project_id}/spiders/{spider_id}/samples/{sample_id}' +
-                 '/annotations{/id}'
+    urlTemplate: '{+host}/api/projects/{parent_sample_spider_project_id}/spiders' +
+                 '/{parent_sample_spider_id}/samples/{parent_sample_id}/annotations{/id}'
 });

--- a/portiaui/app/adapters/field.js
+++ b/portiaui/app/adapters/field.js
@@ -1,5 +1,5 @@
 import SlydJSONAPIAdapter from '../utils/adapter';
 
 export default SlydJSONAPIAdapter.extend({
-    urlTemplate: '{+host}/api/projects/{project_id}/schemas/{schema_id}/fields{/id}'
+    urlTemplate: '{+host}/api/projects/{schema_project_id}/schemas/{schema_id}/fields{/id}'
 });

--- a/portiaui/app/adapters/item-annotation.js
+++ b/portiaui/app/adapters/item-annotation.js
@@ -1,6 +1,6 @@
 import SlydJSONAPIAdapter from '../utils/adapter';
 
 export default SlydJSONAPIAdapter.extend({
-    urlTemplate: '{+host}/api/projects/{project_id}/spiders/{spider_id}/samples/{sample_id}' +
-                 '/item_annotations{/id}'
+    urlTemplate: '{+host}/api/projects/{item_sample_spider_project_id}/spiders' +
+                 '/{item_sample_spider_id}/samples/{item_sample_id}/item_annotations{/id}'
 });

--- a/portiaui/app/adapters/item.js
+++ b/portiaui/app/adapters/item.js
@@ -1,6 +1,6 @@
 import SlydJSONAPIAdapter from '../utils/adapter';
 
 export default SlydJSONAPIAdapter.extend({
-    urlTemplate: '{+host}/api/projects/{project_id}/spiders/{spider_id}/samples/{sample_id}' +
-                 '/items{/id}'
+    urlTemplate: '{+host}/api/projects/{sample_spider_project_id}/spiders/{sample_spider_id}' +
+                 '/samples/{sample_id}/items{/id}'
 });

--- a/portiaui/app/adapters/sample.js
+++ b/portiaui/app/adapters/sample.js
@@ -1,5 +1,5 @@
 import SlydJSONAPIAdapter from '../utils/adapter';
 
 export default SlydJSONAPIAdapter.extend({
-    urlTemplate: '{+host}/api/projects/{project_id}/spiders/{spider_id}/samples{/id}'
+    urlTemplate: '{+host}/api/projects/{spider_project_id}/spiders/{spider_id}/samples{/id}'
 });

--- a/portiaui/app/routes/projects/project.js
+++ b/portiaui/app/routes/projects/project.js
@@ -8,19 +8,21 @@ export default Ember.Route.extend({
     },
 
     afterModel(model) {
-        // XXX: Need to wait for project id to be loaded
-        Ember.run.next(this, function() {
-            this.store.findAll('schema');
-            this.store.findAll('spider');
-            this.store.findAll('extractor');
-            //this.store.findAll('item');
-            //this.store.findAll('item-annotation');
-            //this.store.findAll('annotation');
-        });
-        return model.checkChanges();
+        const id = model.get('id');
+        return Ember.RSVP.all([
+            this.store.query('schema', {
+                project_id: id
+            }),
+            this.store.query('spider', {
+                project_id: id
+            }),
+            this.store.query('extractor', {
+                project_id: id
+            }),
+            model.checkChanges()]);
     },
 
-    setupController: function(controller, model) {
+    setupController(controller, model) {
         this._super(controller, model);
         controller.set('projects', this.controllerFor('projects'));
     },

--- a/portiaui/app/routes/projects/project/schema.js
+++ b/portiaui/app/routes/projects/project/schema.js
@@ -2,7 +2,17 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
     model(params) {
-        return this.store.findRecord('schema', params.schema_id);
+        return this.store.queryRecord('schema', {
+            id: params.schema_id,
+            project_id: this.modelFor('projects.project').get('id')
+        });
+    },
+
+    afterModel(model) {
+        return this.store.query('field', {
+            schema_project_id: this.modelFor('projects.project').get('id'),
+            schema_id: model.get('id')
+        });
     },
 
     renderTemplate() {

--- a/portiaui/app/routes/projects/project/schema/field.js
+++ b/portiaui/app/routes/projects/project/schema/field.js
@@ -2,6 +2,10 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
     model(params) {
-        return this.store.findRecord('field', params.field_id);
+        return this.store.queryRecord('field', {
+            id: params.field_id,
+            schema_id: this.modelFor('projects.project.schema').get('id'),
+            schema_project_id: this.modelFor('projects.project').get('id')
+        });
     }
 });

--- a/portiaui/app/routes/projects/project/spider.js
+++ b/portiaui/app/routes/projects/project/spider.js
@@ -4,7 +4,17 @@ export default Ember.Route.extend({
     browser: Ember.inject.service(),
 
     model(params) {
-        return this.store.findRecord('spider', params.spider_id);
+        return this.store.queryRecord('spider', {
+            id: params.spider_id,
+            project_id: this.modelFor('projects.project').get('id')
+        });
+    },
+
+    afterModel(model) {
+        return this.store.query('sample', {
+            spider_project_id: this.modelFor('projects.project').get('id'),
+            spider_id: model.get('id')
+        });
     },
 
     setupController(controller) {

--- a/portiaui/app/routes/projects/project/spider/sample.js
+++ b/portiaui/app/routes/projects/project/spider/sample.js
@@ -2,13 +2,17 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
     browser: Ember.inject.service(),
-    'extractedItems': Ember.inject.service(),
+    extractedItems: Ember.inject.service(),
 
     model(params) {
-        return this.store.findRecord('sample', params.sample_id);
+        return this.store.queryRecord('sample', {
+            id: params.sample_id,
+            spider_id: this.modelFor('projects.project.spider').get('id'),
+            spider_project_id: this.modelFor('projects.project').get('id')
+        });
     },
 
-    afterModel(model) {
+    afterModel() {
         this.get('extractedItems').update();
     },
 

--- a/portiaui/app/routes/projects/project/spider/sample/data/annotation.js
+++ b/portiaui/app/routes/projects/project/spider/sample/data/annotation.js
@@ -7,7 +7,12 @@ export default Ember.Route.extend({
     selectedModel: Ember.computed.alias('uiState.viewPort.selectedModel'),
 
     model(params) {
-        return this.store.findRecord('annotation', params.annotation_id);
+        return this.store.queryRecord('annotation', {
+            id: params.annotation_id,
+            parent_sample_id: this.modelFor('projects.project.spider.sample').get('id'),
+            parent_sample_spider_id: this.modelFor('projects.project.spider').get('id'),
+            parent_sample_spider_project_id: this.modelFor('projects.project').get('id')
+        });
     },
 
     afterModel(model) {

--- a/portiaui/app/routes/projects/project/spider/sample/data/item.js
+++ b/portiaui/app/routes/projects/project/spider/sample/data/item.js
@@ -2,7 +2,12 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
     model(params) {
-        return this.store.findRecord('item', params.item_id);
+        return this.store.queryRecord('item', {
+            id: params.item_id,
+            sample_id: this.modelFor('projects.project.spider.sample').get('id'),
+            sample_spider_id: this.modelFor('projects.project.spider').get('id'),
+            sample_spider_project_id: this.modelFor('projects.project').get('id')
+        });
     },
 
     actions: {

--- a/portiaui/app/routes/projects/project/spider/sample/item.js
+++ b/portiaui/app/routes/projects/project/spider/sample/item.js
@@ -1,4 +1,0 @@
-import Ember from 'ember';
-
-export default Ember.Route.extend({
-});

--- a/slyd/slyd/resources/models.py
+++ b/slyd/slyd/resources/models.py
@@ -229,7 +229,12 @@ class SampleSchema(SlydSchema):
     )
 
     def dump(self, obj, many=None, update_fields=True, **kwargs):
-        obj.setdefault('items', [])
+        many = self.many if many is None else bool(many)
+        if many:
+            for o in obj:
+                o.setdefault('items', [])
+        else:
+            obj.setdefault('items', [])
         return super(SampleSchema, self).dump(obj, many, update_fields,
                                               **kwargs)
 


### PR DESCRIPTION
resolves errors generating urls when a parent model id is unavailable
* explicitly pass ids as parameters from routes using store.query and store.queryRecord
* resolve ids using snapshot api when a snapshot is available