### PR TITLE
Recommend Ubuntu Trusty

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -48,7 +48,7 @@ Debian
 Running Portia Locally
 ^^^^^^^^^^^^^^^^^^^^^^
 
-**These instructions are only valid for a Debian based OS**
+**These instructions are only valid for a Debian based OS (Ubuntu 14.04 recommended)**
 
 Install the following dependencies::
 


### PR DESCRIPTION
It appears that Ububtu 14.04 is targeted based upon:
- https://github.com/scrapinghub/portia/blob/72fb6700d37e081f169271478a07e712cdaf13f5/provision.sh#L52
- https://github.com/scrapinghub/portia/blob/72fb6700d37e081f169271478a07e712cdaf13f5/Vagrantfile#L4
- https://github.com/scrapinghub/portia/blob/72fb6700d37e081f169271478a07e712cdaf13f5/Dockerfile#L1
- Add note recommending the currently targeted platform as many
  developers have an open choice of which to choose
