### PR TITLE
permissions are wrong when starting slyd and nginx from vagrant 

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -109,8 +109,8 @@ configure_initctl(){
     cp "$APP_ROOT/slyd.conf" /etc/init
     echo "Starting slyd service"
     echo "====================="
-    /etc/init.d/nginx start
-    start slyd
+    sudo /etc/init.d/nginx restart
+    sudo start slyd
 }
 
 if [ \( $# -eq 0 \) -o \( "$1" = "-h" \) -o \( "$1" = "--help" \) ]; then


### PR DESCRIPTION
When building the vagrant slyd and nginx is not correctly started because it lacks permissions to access logs etc and you should "vagrant ssh" and start these services manually. 

I have added sudo to both commands and changed "nginx start" for "nginx restart". This way i get it to start correctly.

I found this problem with this setup:

* OsX 10.11.2 El Capitán
* vagrant 1.8.1