### PR TITLE
Handle ConnectionLost and OperationalError in connection pool with retry

### DIFF
--- a/slyd/slyd/gitstorage/projectspec.py
+++ b/slyd/slyd/gitstorage/projectspec.py
@@ -13,6 +13,7 @@ class GitProjectSpec(GitProjectMixin, ProjectSpec):
     def __init__(self, project_name, auth_info):
         super(GitProjectSpec, self).__init__(project_name, auth_info)
         self._changed_file_data = {}
+        self.connection = None
 
     @classmethod
     def setup(cls, storage_backend, location, **kwargs):

--- a/slyd/slyd/projectspec.py
+++ b/slyd/slyd/projectspec.py
@@ -189,7 +189,7 @@ class ProjectSpec(object):
         return '%s(%s)' % (self.__class__.__name__, str(self))
 
     def __str__(self):
-        return '%s, %s' % (self.project_name, self.username)
+        return '%s, %s' % (self.project_name, self.user)
 
 
 class ProjectResource(SlydJsonObjectResource, ProjectModifier):


### PR DESCRIPTION
Subclass `twisted.enterprise.adbapi.ConnectionPool` to add a custom `_runWithConnection` for handling errors.
Move reconnection code to `slyd.gitstorage.repo` from `slyd.gitstorage.projects`
