### PR TITLE
Add optinonal page_clustering to slybot

### DIFF
--- a/slybot/requirements-clustering.txt
+++ b/slybot/requirements-clustering.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+page_clustering==0.0.1

--- a/slybot/setup.py
+++ b/slybot/setup.py
@@ -4,7 +4,8 @@ from setuptools import setup, find_packages
 install_requires = ['Scrapy', 'scrapely', 'loginform', 'lxml', 'jsonschema',
                     'dateparser', 'scrapyjs', 'page_finder']
 extras = {
-    'tests': ['nose', 'nose-timer']
+    'tests': ['nose', 'nose-timer'],
+    'clustering': ['page_clustering']
 }
 
 setup(name='slybot',


### PR DESCRIPTION
When PAGE_CLUSTERING setting is enabled (and extra `page_clustering` module has been installed), the most probable template according to the clustering algorithm will be suggested as the preferred template for item extraction.