### PR TITLE
Fix HTML entities escaping for resources

### DIFF
--- a/slyd/slyd/html.py
+++ b/slyd/slyd/html.py
@@ -11,7 +11,7 @@ from six.moves.urllib_parse import urljoin
 
 from scrapely.htmlpage import HtmlTag, HtmlTagType, parse_html
 from slybot.utils import htmlpage_from_response
-from .splash.css_utils import process_css, wrap_url, unscape
+from .splash.css_utils import process_css, wrap_url, unescape
 from .utils import serialize_tag, add_tagids
 
 URI_ATTRIBUTES = ("action", "background", "cite", "classid", "codebase",
@@ -71,7 +71,7 @@ def descriptify(doc, base=None, proxy=None):
                         element.attributes[key] = '/static/frames-not-supported.html'
                     # Rewrite javascript URIs
                     elif key in URI_ATTRIBUTES and val is not None:
-                            if _contains_js(unscape(val)):
+                            if _contains_js(unescape(val)):
                                 element.attributes[key] = "#"
                             elif base and proxy and not (element.tag == "a" and key == 'href'):
                                 element.attributes[key] = wrap_url(val, -1,

--- a/slyd/slyd/html.py
+++ b/slyd/slyd/html.py
@@ -6,13 +6,12 @@
 """
 from __future__ import absolute_import
 import re
-import six
 
 from six.moves.urllib_parse import urljoin
 
 from scrapely.htmlpage import HtmlTag, HtmlTagType, parse_html
 from slybot.utils import htmlpage_from_response
-from .splash.css_utils import process_css, wrap_url
+from .splash.css_utils import process_css, wrap_url, unscape
 from .utils import serialize_tag, add_tagids
 
 URI_ATTRIBUTES = ("action", "background", "cite", "classid", "codebase",
@@ -24,23 +23,6 @@ _ALLOWED_CHARS_RE = re.compile('[^!-~]') # [!-~] = ascii printable characters
 def _contains_js(url):
     return _ALLOWED_CHARS_RE.sub('', url).lower().startswith('javascript:')
 
-try:
-    from html import unescape
-except ImportError:
-    # https://html.spec.whatwg.org/multipage/syntax.html#character-references
-    # http://stackoverflow.com/questions/18689230/why-do-html-entity-names-with-dec-255-not-require-semicolon
-    _ENTITY_RE = re.compile("&#(\d+|x[a-f\d]+);?", re.I)
-    def _replace_entity(match):
-        entity = match.group(1)
-        if entity[0].lower() == 'x':
-            return six.unichr(int(entity[1:], 16))
-        else:
-            return six.unichr(int(entity, 10))
-
-    def unscape(mystr):
-        """replaces all numeric html entities by its unicode equivalent.
-        """
-        return _ENTITY_RE.sub(_replace_entity, mystr)
 
 def html4annotation(htmlpage, baseurl=None, proxy_resources=None):
     """Convert the given html document for the annotation UI

--- a/slyd/slyd/splash/css_utils.py
+++ b/slyd/slyd/splash/css_utils.py
@@ -1,12 +1,37 @@
 import re
 import urllib
+import six
+import htmlentitydefs
 from six.moves.urllib_parse import urlparse, urljoin
-
 
 CSS_IMPORT = re.compile(r'''@import\s*["']([^"']+)["']''')
 CSS_URL = re.compile(r'''\burl\(("[^"]+"|'[^']+'|[^"')][^)]+)\)''')
 BAD_CSS = re.compile(r'''(-moz-binding|expression\s*\(|javascript\s*:)''', re.I)
 
+# https://html.spec.whatwg.org/multipage/syntax.html#character-references
+# http://stackoverflow.com/questions/18689230/why-do-html-entity-names-with-dec-255-not-require-semicolon
+_ENTITY_RE = re.compile("&#?\w+;", re.I)
+def _replace_entity(match):
+    entity = match.group(0)
+    if entity[:2] == "&#":
+        # character reference
+        if entity[:3] == "&#x":
+        if entity[:3] == "&#x":
+            return six.unichr(int(entity[3:-1], 16))
+        else:
+            return six.unichr(int(entity[2:-1]))
+    else:
+        # named entity
+        try:
+            return six.unichr(htmlentitydefs.name2codepoint[entity[1:-1]])
+        except KeyError:
+            pass
+        return entity # leave as is
+
+def unscape(mystr):
+    """replaces all numeric html entities by its unicode equivalent.
+    """
+    return _ENTITY_RE.sub(_replace_entity, mystr)
 
 def wrap_url(url, tabid, base=None):
     url = url.strip()
@@ -24,9 +49,9 @@ def wrap_url(url, tabid, base=None):
         return url  # TODO: process CSS inside data: urls
     if parsed.scheme not in ('http', 'https', 'ftp'):
         return 'data:text/plain,invalid_scheme'
-
+    
     return "/proxy?" + urllib.urlencode({
-        "url": url,
+        "url": unscape(url),
         "referer": referer,
         "tabid": tabid
     })

--- a/slyd/slyd/splash/css_utils.py
+++ b/slyd/slyd/splash/css_utils.py
@@ -1,7 +1,7 @@
 import re
 import urllib
 import six
-import htmlentitydefs
+import six.moves.html_entities as htmlentitydefs
 from six.moves.urllib_parse import urlparse, urljoin
 
 CSS_IMPORT = re.compile(r'''@import\s*["']([^"']+)["']''')
@@ -28,7 +28,7 @@ def _replace_entity(match):
             pass
         return entity # leave as is
 
-def unscape(mystr):
+def unescape(mystr):
     """replaces all numeric html entities by its unicode equivalent.
     """
     return _ENTITY_RE.sub(_replace_entity, mystr)
@@ -51,7 +51,7 @@ def wrap_url(url, tabid, base=None):
         return 'data:text/plain,invalid_scheme'
     
     return "/proxy?" + urllib.urlencode({
-        "url": unscape(url),
+        "url": unescape(url),
         "referer": referer,
         "tabid": tabid
     })


### PR DESCRIPTION
Fix an issue preventing resources containing HTML entities from loading
when annotating a page.

----------------------------------------------------

When annotating a page like:
https://www.facebook.com/bbcnews/

Some resources (images/css/..) are not handled during the annotation because their URL includes html entities.

[https://scontent.xx.fbcdn.net/v/t1.0-1/p160x160/1926656_10151955586072217_265500303_n.png?oh=65b239d3092a2de944f218fe7a8e991b**&**oe=58069918](https://scontent.xx.fbcdn.net/v/t1.0-1/p160x160/1926656_10151955586072217_265500303_n.png?oh=65b239d3092a2de944f218fe7a8e991b&oe=58069918)

is saved (in the Tenplate file) as:

[https://scontent.xx.fbcdn.net/v/t1.0-1/p160x160/1926656_10151955586072217_265500303_n.png?oh=65b239d3092a2de944f218fe7a8e991b**&amp;amp;**oe=58069918](https://scontent.xx.fbcdn.net/v/t1.0-1/p160x160/1926656_10151955586072217_265500303_n.png?oh=65b239d3092a2de944f218fe7a8e991b&oe=58069918)

HTML entities within URLs should be interpeted automatically by the browser, however portia is not referencing the resources directly but through a proxy.
After encoding, the URL given to the browser will look like:

[/proxy?url=https%3A%2F%2Fscontent.xx.fbcdn.net%2Fv%2Ft1.0-1%2Fp160x160%2F1926656_10151955586072217_265500303_n.png%3Foh%3D65b239d3092a2de944f218fe7a8e991b**%26amp%3B**oe%3D58069918](url)

When it should be:

[/proxy?url=https%3A%2F%2Fscontent.xx.fbcdn.net%2Fv%2Ft1.0-1%2Fp160x160%2F1926656_10151955586072217_265500303_n.png%3Foh%3D65b239d3092a2de944f218fe7a8e991b**%26**oe%3D58069918](url)

The fix I applied was to change the wrap_url method in order to decode HTML entities before saving URLS.