### PR TITLE
Add optional page_clustering to slybot

### DIFF
--- a/slybot/requirements-clustering.txt
+++ b/slybot/requirements-clustering.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+page_clustering==0.0.1

--- a/slybot/setup.py
+++ b/slybot/setup.py
@@ -4,7 +4,8 @@ from setuptools import setup, find_packages
 install_requires = ['Scrapy', 'scrapely', 'loginform', 'lxml', 'jsonschema',
                     'dateparser', 'scrapyjs', 'page_finder']
 extras = {
-    'tests': ['nose', 'nose-timer']
+    'tests': ['nose', 'nose-timer'],
+    'clustering': ['page_clustering']
 }
 
 setup(name='slybot',

--- a/slybot/slybot/plugins/scrapely_annotations/annotations.py
+++ b/slybot/slybot/plugins/scrapely_annotations/annotations.py
@@ -27,10 +27,11 @@ class Annotations(object):
     Base Class for adding plugins to Portia Web and Slybot.
     """
 
-    def setup_bot(self, settings, spec, items, extractors):
+    def setup_bot(self, settings, spec, items, extractors, logger):
         """
         Perform any initialization needed for crawling using this plugin
         """
+        self.logger = logger
         _item_template_pages = sorted((
             [t.get('scrapes'), dict_to_page(t, 'annotated_body'),
              t.get('extractors', []), t.get('version', '0.12.0')]
@@ -97,10 +98,15 @@ class Annotations(object):
             try:
                 import page_clustering
                 self.clustering = page_clustering.kmeans_from_samples(spec['templates'])
+                self.logger.info("Clustering activated")
             except ImportError:
                 self.clustering = None
+                self.logger.warning(
+                    "Clustering could not be used because it is not installed")
         else:
             self.clustering = None
+            self.logger.info(
+                "Clustering setting deactivated")
 
     def handle_html(self, response, seen=None):
         htmlpage = htmlpage_from_response(response)

--- a/slybot/slybot/plugins/selectors/__init__.py
+++ b/slybot/slybot/plugins/selectors/__init__.py
@@ -1,6 +1,7 @@
 
 class Selectors(object):
-    def setup_bot(self, settings, spec, items, extractors):
+    def setup_bot(self, settings, spec, items, extractors, logger):
+        self.logger = logger
         self.selectors = {} # { template_id: { field_name: {..} }
 
         for template in spec['templates']:
@@ -28,4 +29,3 @@ class Selectors(object):
             item[field] = ([item[field]] + result) if field in item else result
 
 __all__ = [Selectors]
-

--- a/slybot/slybot/spider.py
+++ b/slybot/slybot/spider.py
@@ -198,7 +198,7 @@ class IblSpider(SitemapSpider):
         for plugin_class, plugin_name in zip(load_plugins(settings),
                                              load_plugin_names(settings)):
             instance = plugin_class()
-            instance.setup_bot(settings, spec, schemas, extractors)
+            instance.setup_bot(settings, spec, schemas, extractors, self.logger)
             plugins[plugin_name] = instance
         return plugins
 


### PR DESCRIPTION
`page_clustering` package can be applied to find the most probable template to apply when a new page to be scrapped is crawled. This is a completely optional feature.