### PR TITLE
Populate project relationship from manager

### DIFF
--- a/slyd/slyd/resources/spiders.py
+++ b/slyd/slyd/resources/spiders.py
@@ -56,7 +56,8 @@ def update_spider(manager, spider_id, attributes):
         if 'samples' in spider:
             del spider['samples']
         response = SpiderSchema(context=context).dump(spider).data
-        spider = _populate_relationships(spider, spider_id)
+        spider = _populate_relationships(
+            manager.project_name, spider, spider_id)
         new_spider = SpiderSchema(context=context).dump(spider).data
         response['included'] = [new_spider['data']]
         response['data']['attributes']['name'] = "_deleted"
@@ -84,7 +85,7 @@ def _check_spider_attributes(attributes, include_defaults=False):
 def _load_spider(manager, spider_id, include_samples=False):
     spider = manager.spider_json(spider_id)
     spider['id'] = spider_id
-    spider = _populate_relationships(spider, spider_id)
+    spider = _populate_relationships(manager.project_name, spider, spider_id)
     if include_samples:
         samples = []
         for name in spider['template_names']:
@@ -95,9 +96,10 @@ def _load_spider(manager, spider_id, include_samples=False):
     return spider
 
 
-def _populate_relationships(spider, spider_id):
+def _populate_relationships(project_id, spider, spider_id):
     if not spider.get('name'):
         spider['name'] = spider_id
+    spider['project'] = {'id': project_id}
     spider['samples'] = [
         {'id': name} for name in spider.get('template_names', [])
     ]


### PR DESCRIPTION
When copying a spider from portia 1.0 to portia 2.0 the project id was populated from the previous project rather than the new project.