### PR TITLE
Improve repeated items for slybot

### DIFF
--- a/slybot/requirements.txt
+++ b/slybot/requirements.txt
@@ -2,10 +2,10 @@
 scrapy==1.1.0
 scrapely==0.12.0
 loginform==1.0
-lxml==3.4.1
-dateparser==0.2
+lxml==3.6.0
+dateparser==0.3.5
 python-dateutil<=2.4.2
 jsonschema==2.4.0
 six==1.10.0
 scrapyjs==0.1.1
-page_finder==0.1.1
+page_finder==0.1.2

--- a/slybot/slybot/plugins/scrapely_annotations/builder.py
+++ b/slybot/slybot/plugins/scrapely_annotations/builder.py
@@ -8,6 +8,7 @@ from itertools import tee, count, chain, groupby
 from operator import itemgetter
 from uuid import uuid4
 
+from .migration import _get_parent
 from .utils import (serialize_tag, add_tagids, remove_tagids, TAGID,
                     OPEN_TAG, CLOSE_TAG, UNPAIRED_TAG, GENERATEDTAGID)
 
@@ -308,12 +309,35 @@ def apply_selector_annotations(annotations, target_page):
             elems = accepted_elements - rejected_elements
         else:
             elems = [elem._root for elem in page.css(annotation['selector'])]
-        if elems:
-            tagids = [int(e.attrib.get('data-tagid', 1e9)) for e in elems]
-            tagid = min(tagids)
-            if tagid is not None:
-                annotation['tagid'] = tagid
-                converted_annotations.append(annotation)
+        if not elems:
+            continue
+
+        tagids = [int(e.attrib.get('data-tagid', 1e9)) for e in elems]
+        tagid = min(tagids)
+        if tagid is not None:
+            annotation['tagid'] = tagid
+            converted_annotations.append(annotation)
+
+        # Create container for repeated field annotation
+        if (annotation.get('repeated') and
+                not annotation.get('item_container') and
+                len(annotation.get('annotations')) == 1):
+            parent = _get_parent(elems, page)
+            field = annotation['annotations'].values()[0][0]['field']
+            container_id = '%s#parent' % annotation['id']
+            if len(parent):
+                converted_annotations.append({
+                    'item_container': True,
+                    'id': container_id,
+                    'annotations': {'#portia-content': '#dummy'},
+                    'text-content': '#portia-content',
+                    'container_id': annotation['container_id'],
+                    'field': field,
+                    'tagid': parent.attrib.get('data-tagid')
+                })
+                annotation['item_container'] = True
+                annotation['field'] = field
+                annotation['container_id'] = container_id
     return converted_annotations
 
 

--- a/slybot/slybot/plugins/scrapely_annotations/extraction.py
+++ b/slybot/slybot/plugins/scrapely_annotations/extraction.py
@@ -70,7 +70,7 @@ def group_tree(tree, container_annotations):
     get_first = itemgetter(0)
     for name, value in groupby(sorted(tree, key=get_first), get_first):
         value = list(value)
-        if len(value) == 1:
+        if len(value) <= 1:
             result[name] = container_annotations.get(name)
         else:
             result[name] = group_tree([l[1:] for l in value if len(l) > 1],
@@ -151,6 +151,20 @@ class BaseExtractor(BasicTypeExtractor):
     def _create_basic_extractor(cls, annotation, attribute_descriptors):
         return cls(annotation, attribute_descriptors)
 
+    def __str__(self):
+        messages = [self.__class__.__name__, '(']
+        annotation = self.annotation
+        messages.append(self.annotation.surrounds_attribute or '')
+
+        if annotation.tag_attributes:
+            if annotation.surrounds_attribute:
+                messages.append(';')
+            for (f, ta, ea) in self.tag_data:
+                messages += [ea, ': attribute "', ta, '"']
+        start, end = annotation.start_index, annotation.end_index
+        messages.append(', template[%s:%s])' % (start, end))
+        return ''.join(map(str, messages))
+
 
 class SlybotRecordExtractor(RecordExtractor):
     def extract(self, page, start_index=0, end_index=None,
@@ -164,7 +178,8 @@ class SlybotRecordExtractor(RecordExtractor):
             ignored_regions = []
         extractors = sorted(self.extractors + ignored_regions,
                             key=lambda x: labelled_element(x).start_index)
-        _, _, attributes = self._doextract(page, extractors + ignored_regions, start_index,
+        _, _, attributes = self._doextract(page, extractors + ignored_regions,
+                                           start_index,
                                            end_index, **kwargs)
         return list(attributes)
 
@@ -270,7 +285,7 @@ class BaseContainerExtractor(object):
         RecordExtractor,
     ]
 
-    def __init__(self, extractors, template, legacy=False):
+    def __init__(self, extractors, template):
         schema_name = None
         if hasattr(self, 'annotation'):
             schema_name = self.annotation.metadata.get('schema_id')
@@ -278,13 +293,12 @@ class BaseContainerExtractor(object):
         self.modifiers = template.modifiers
         extra_requires = getattr(self, 'extra_requires', [])
         self.extra_requires = extra_requires
-        self.legacy = legacy
         if hasattr(self.schema, '_required_attributes'):
             requires = list(extra_requires) + self.schema._required_attributes
             self.schema._required_attributes = requires
 
     @classmethod
-    def apply(cls, template, extractors, legacy=False):
+    def apply(cls, template, extractors):
         # Group containers and get container info
         container_info = cls._get_container_data(extractors)
         containers, container_annos, non_container_annos = container_info
@@ -294,11 +308,11 @@ class BaseContainerExtractor(object):
 
         # Build containerized extractors
         container_extractors = cls._build_containerized_extractors(
-            containers, container_annos, template, tree, legacy)
+            containers, container_annos, template, tree)
         return non_container_annos + container_extractors
 
     def _build_extractors(self, extractors, containers, container_contents,
-                          template, legacy=False):
+                          template):
         new_extractors = []
         annotation = None
         if isinstance(extractors, list):  # Bottom of extraction tree
@@ -306,22 +320,15 @@ class BaseContainerExtractor(object):
             for ex in extractors:
                 fields = ex.annotation.metadata.get('required_fields', [])
                 self.extra_requires.update(fields)
-            if self.legacy:  # Mimic old slybot behaviour
-                for extractor_cls in self._extractor_classes:
-                    extractors = extractor_cls.apply(template, extractors)
-                new_extractors.extend(extractors)
-            else:
-                new_extractors.extend(
-                    SlybotRecordExtractor.apply(template, extractors))
+            new_extractors.extend(
+                SlybotRecordExtractor.apply(template, extractors))
         else:
-            for container_name, container_data in extractors.items():
+            for container_name, container_data in (extractors or {}).items():
                 annotation = self._find_annotation(template, container_name)
-                if container_name not in containers or not container_contents:
-                    continue  # Ignore missing or empty containers
                 if annotation.metadata.get('item_container'):
                     self._add_new_container(
                         annotation, new_extractors, container_data, template,
-                        containers, container_contents, legacy)
+                        containers, container_contents)
         if not hasattr(self, 'annotation'):
             self.annotation = None
         if annotation:
@@ -382,7 +389,7 @@ class BaseContainerExtractor(object):
 
     @classmethod
     def _build_containerized_extractors(cls, containers, container_annos,
-                                        template, tree, legacy):
+                                        template, tree):
         """
         Convert container annotation trees into container extractors.
         """
@@ -399,32 +406,24 @@ class BaseContainerExtractor(object):
             if container:
                 cls._add_new_container(
                     annotation, container_extractors, container_data,
-                    template, container_annos, container, legacy)
+                    template, container_annos, container)
         return container_extractors
 
     @staticmethod
     def _add_new_container(annotation, extractors, container_data, template,
-                           containers, container_contents, legacy):
+                           containers, container_contents):
         """
         Create a new container from the provided container information.
         """
-        if annotation.metadata.get('repeated'):
-            extractors.append(
-                RepeatedContainerExtractor(
-                    container_data, template,
-                    containers=containers,
-                    container_contents=container_contents,
-                    legacy=legacy)
-            )
-        else:
-            extractors.append(
-                ContainerExtractor(
-                    container_data, template,
-                    annotation=annotation,
-                    containers=containers,
-                    container_contents=container_contents,
-                    legacy=legacy)
-            )
+        meta = annotation.metadata
+        cls = ContainerExtractor
+        if meta.get('repeated'):
+            cls = RepeatedContainerExtractor
+            if meta.get('field'):
+                cls = RepeatedFieldsExtractor
+        extractors.append(
+            cls(container_data, template, annotation=annotation,
+                containers=containers, container_contents=container_contents))
 
     def _find_annotation(self, template, annotation_id):
         """
@@ -454,9 +453,11 @@ class BaseContainerExtractor(object):
         new_item = defaultdict(list)
         if isinstance(item, dict):
             item = item.items()
-        elif item and not isinstance(item[0], tuple):
+        elif item and not isinstance(item[0], (tuple, dict)):
             item = [item]
-        for k, v in item:
+        item_fields = (list(i.items()) if hasattr(i, 'items') else (i,)
+                       for i in item)
+        for k, v in chain(*item_fields):
             if hasattr(k, 'startswith'):
                 if k.startswith('_'):
                     new_item[k] = v
@@ -517,11 +518,6 @@ class BaseContainerExtractor(object):
                     raise MissingRequiredError()
                 yield (field_extraction, extracted)
             else:
-                # Legacy spiders have per attribute pipline extractors
-                if self.legacy and annotation == 'variants':
-                    yield (annotation, self._process_variants(regions,
-                                                              htmlpage))
-                    continue
                 try:
                     extraction_func = self.schema.attribute_map.get(annotation)
                 except AttributeError:
@@ -532,15 +528,6 @@ class BaseContainerExtractor(object):
                 values = self._process_values(regions, htmlpage,
                                               extraction_func)
                 yield (extraction_func, values)
-
-    def _process_variants(self, data, htmlpage):
-        variants = []
-        for item in data:
-            item = self._validate_and_adapt_item(item, htmlpage)
-            if item:
-                item.pop('_type', None)
-                variants.append(item)
-        return variants
 
     def _process_values(self, regions, htmlpage, extraction_func):
         values = []
@@ -571,24 +558,38 @@ class BaseContainerExtractor(object):
 
 class ContainerExtractor(BaseContainerExtractor, BasicTypeExtractor):
     def __init__(self, extractors, template, containers=None,
-                 container_contents=None, annotation=None, legacy=False,
+                 container_contents=None, annotation=None,
                  required_fields=None):
         if containers is None:
             containers = {}
         if container_contents is None:
             container_contents = {}
-        self.legacy = legacy
+        if annotation is not None:
+            aid = annotation.metadata.get('id')
+        else:
+            aid = None
         self.template_tokens = template.page_tokens
         self.template_token_dict = template.token_dict
         self.extractors = self._build_extractors(
-            extractors, containers, container_contents, template, legacy)
+            extractors, containers, container_contents, template)
+        record = [e for e in containers.get(aid, [])
+                  if not e.annotation.metadata.get('item_container')]
+        if record and not isinstance(extractors, list):
+            self.extractors.extend(
+                SlybotRecordExtractor.apply(template, record))
         self.content_validate = lambda x: x
         self.best_match = longest_unique_subsequence
         if annotation:
             self.annotation = annotation
-        BaseContainerExtractor.__init__(self, extractors, template, legacy)
+        BaseContainerExtractor.__init__(self, extractors, template)
         if required_fields:
             self.extra_requires = set(required_fields) | self.extra_requires
+        # A Container can only extract many items if it has at least one child
+        # RepeatedContainerExtractor
+        self.many = False
+        if (any(isinstance(e, RepeatedContainerExtractor)
+                for e in self.extractors)):
+            self.many = True
 
     def extract(self, page, start_index=0, end_index=None,
                 ignored_regions=None, **kwargs):
@@ -609,7 +610,10 @@ class ContainerExtractor(BaseContainerExtractor, BasicTypeExtractor):
             return []
         items = self._extract_items_from_region(region, page, ignored_regions,
                                                 **kwargs)
-        return [self._validate_and_adapt_item(i, page) for i in items]
+        items = [self._validate_and_adapt_item(i, page) for i in items]
+        if self.many:
+            return items
+        return self._merge_items(items)
 
     def _extract_items_from_region(self, region, page, ignored_regions, **kw):
         items = []
@@ -640,25 +644,46 @@ class ContainerExtractor(BaseContainerExtractor, BasicTypeExtractor):
                 items.append(item)
         return items
 
+    def _merge_items(self, items):
+        result = defaultdict(list)
+        for item in items:
+            if hasattr(item, 'items'):
+                item = item.items()
+            for k, v in item:
+                if isinstance(v, list):
+                    result[k].extend(v)
+                else:
+                    # Overwrites different item types
+                    result[k] = v
+        return [dict(result)]
+
 
 class RepeatedContainerExtractor(BaseContainerExtractor, RecordExtractor):
     def __init__(self, extractors, template, containers=None,
-                 container_contents=None, schemas=None, legacy=False):
+                 container_contents=None, annotation=None, schemas=None):
         if containers is None:
             containers = {}
         if container_contents is None:
             container_contents = {}
         if schemas is None:
             schemas = {}
-        self.legacy = legacy
+        if annotation is not None:
+            aid = annotation.metadata.get('id')
+        else:
+            aid = None
         self.template_tokens = template.page_tokens
         self.template_token_dict = template.token_dict
         self.prefix, self.suffix = self._find_prefix_suffix(
             extractors, container_contents, containers, template)
         self.extractors = self._build_extractors(
-            extractors, containers, container_contents, template, legacy)
+            extractors, containers, container_contents, template)
+        record = [e for e in containers.get(aid, [])
+                  if not e.annotation.metadata.get('item_container')]
+        if record and not isinstance(extractors, list):
+            self.extractors.extend(
+                SlybotRecordExtractor.apply(template, record))
         self.best_match = first_longest_subsequence
-        BaseContainerExtractor.__init__(self, extractors, template, legacy)
+        BaseContainerExtractor.__init__(self, extractors, template)
 
     def extract(self, page, start_index=0, end_index=None,
                 ignored_regions=None, **kwargs):
@@ -679,23 +704,31 @@ class RepeatedContainerExtractor(BaseContainerExtractor, RecordExtractor):
             prefix_end = index + prefixlen
             if (page.page_tokens[index:prefix_end] == self.prefix).all():
                 for peek in xrange(prefix_end + self.min_jump, max_index + 1):
-                    if (page.page_tokens[peek:peek + suffixlen]
-                            == self.suffix).all():
-                        try:
-                            for extractor in self.extractors:
-                                items = extractor.extract(
-                                    page, index, peek + self.offset,
-                                    ignored_regions,
-                                    suffix_max_length=suffixlen)
-                                if items:
-                                    extracted.extend([
-                                        self._validate_and_adapt_item(items,
-                                                                      page)
-                                    ])
-                                index = max(peek, index) - 1
-                        except MissingRequiredError:
-                            pass
-                        break
+                    next_prefix = page.page_tokens[peek:peek + prefixlen]
+                    next_suffix = page.page_tokens[peek:peek + suffixlen]
+                    matches_next_prefix = (next_prefix == self.prefix).all()
+                    matches_next_suffix = (next_suffix == self.suffix).all()
+                    if not (matches_next_suffix or matches_next_prefix or
+                            peek + suffixlen >= max_index):
+                        continue
+                    if matches_next_prefix:
+                        peek -= suffixlen + 1
+                    try:
+                        items = []
+                        _index = index
+                        for extractor in self.extractors:
+                            items += extractor.extract(
+                                page, index, peek + self.offset,
+                                ignored_regions,
+                                suffix_max_length=suffixlen)
+                            _index = max(peek, index) - 1
+                    except MissingRequiredError:
+                        pass
+                    else:
+                        extracted.extend(
+                            self._process_items(items, page))
+                    index = _index
+                    break
             index += 1
         result = []
         for i, item in enumerate(extracted, 1):
@@ -710,54 +743,47 @@ class RepeatedContainerExtractor(BaseContainerExtractor, RecordExtractor):
             return [(self.parent_annotation.metadata['field'], result)]
         return result
 
+    def _process_items(self, items, page):
+        if not items:
+            return []
+        return arg_to_iter(self._validate_and_adapt_item(items, page))
+
     def _find_prefix_suffix(self, extractors, container_contents, containers,
                             template):
         """
         Find the prefix and suffix for this repeating extractor.
         """
+        htt = HtmlTagType
+        all_tags = (htt.CLOSE_TAG, htt.UNPAIRED_TAG, htt.OPEN_TAG)
+        open_tags = (htt.OPEN_TAG, htt.UNPAIRED_TAG)
         parent, child = self._find_siblings(template, containers,
                                             container_contents)
         self.parent_annotation = parent
         parent_sindex = 0 if not parent else parent.start_index
-        htt = HtmlTagType
         tokens = template.page_tokens[parent_sindex:child.start_index + 1]
-        prefix_tokens = self._find_tokens(tokens,
-                                          (htt.OPEN_TAG, htt.UNPAIRED_TAG),
-                                          template)
-        prefix_tokens.reverse()
+        prefix = self._find_tokens(tokens, open_tags, template)
+        prefix.reverse()
         tokens = template.page_tokens[child.start_index + 1:
                                       child.end_index + 1]
-        suffix_tokens = self._find_tokens(tokens,
-                                          (htt.CLOSE_TAG, htt.UNPAIRED_TAG,
-                                           htt.OPEN_TAG),
-                                          template)
-        prefix_tokens = self._trim_prefix(prefix_tokens, suffix_tokens,
-                                          template)
-        suffix_tokens.reverse()
-        suffix_tokens = self._trim_prefix(suffix_tokens, prefix_tokens,
-                                          template, 3)
+        suffix = self._find_tokens(tokens, all_tags, template)
+        prefix = self._trim_prefix(prefix, suffix, template)
+        suffix.reverse()
+        suffix = self._trim_prefix(suffix, prefix, template, 3)
         tokens = template.page_tokens[child.start_index + 1:
                                       child.end_index][::-1]
         max_separator = int(len(tokens) * MAX_RELATIVE_SEPARATOR_MULTIPLIER)
-        tokens = self._find_tokens(tokens,
-                                   (htt.OPEN_TAG, htt.UNPAIRED_TAG),
-                                   template)
-        prefix_tokens = self._trim_prefix(prefix_tokens + tokens,
-                                          suffix_tokens,
-                                          template, 3, True)
+        tokens = self._find_tokens(tokens, open_tags, template)
+        prefix = self._trim_prefix(
+            prefix + tokens, suffix, template, 3, True)
         tokens = template.page_tokens[child.end_index + 1:
                                       child.end_index + max_separator][::-1]
-        tokens = self._find_tokens(tokens,
-                                   (htt.OPEN_TAG, htt.UNPAIRED_TAG),
-                                   template, prefix_tokens[0])
+        tokens = self._find_tokens(tokens, open_tags, template, prefix[0])
         self.offset = 1 if not tokens else 0
-        suffix_tokens = self._trim_prefix(suffix_tokens + tokens,
-                                          prefix_tokens,
-                                          template, 3, True)
+        suffix = self._trim_prefix(suffix + tokens, prefix, template, 3, True)
         # Heuristic to reduce chance of false positives
         self.min_jump = int((child.end_index - child.start_index -
-                             len(suffix_tokens)) * MIN_JUMP_DISTANCE)
-        return (array(prefix_tokens), array(suffix_tokens))
+                             len(suffix)) * MIN_JUMP_DISTANCE)
+        return (array(prefix), array(suffix))
 
     def _find_siblings(self, template, containers, container_contents):
         child_id = container_contents[0].annotation.metadata['container_id']
@@ -859,6 +885,36 @@ class RepeatedContainerExtractor(BaseContainerExtractor, RecordExtractor):
         return result_tokens
 
 
+class RepeatedFieldsExtractor(RepeatedContainerExtractor):
+    def __init__(self, extractors, template, containers=None,
+                 container_contents=None, annotation=None, schemas=None):
+        extractors = [BaseExtractor(annotation, schemas)]
+        self.annotation = annotation
+        RepeatedContainerExtractor.__init__(
+            self, extractors, template, containers, container_contents,
+            schemas)
+        self.extractors = [RepeatedDataExtractor(
+            [self.prefix[-2:]], [self.suffix[:1]],
+            [BaseExtractor(annotation, self.schema)])]
+
+    def extract(self, page, start_index=0, end_index=None,
+                ignored_regions=None, **kwargs):
+        data = self.extractors[0].extract(
+            page, start_index, end_index, ignored_regions, **kwargs)
+        if not data:
+            return []
+        values = [v for _, v in data]
+        return [(data[0][0], values)]
+
+    def _validate_and_adapt_item(self, item):
+        return item
+
+    def _find_siblings(self, template, containers, container_contents):
+        container_id = self.annotation.metadata['container_id']
+        parent = self._find_annotation(template, container_id)
+        return parent, self.annotation
+
+
 class TemplatePageMultiItemExtractor(TemplatePageExtractor):
     def extract(self, page, start_index=0, end_index=None):
         items = []
@@ -901,18 +957,17 @@ class SlybotIBLExtractor(InstanceBasedLearningExtractor):
             parsed_templates, key=_annotation_count, reverse=True
         )
         self.extraction_trees = [
-            self.build_extraction_tree(p, None, trace, legacy=v < '0.13.0')
+            self.build_extraction_tree(p, None, trace)
             for p, v in zip(parsed_templates, template_versions)
         ]
 
     def build_extraction_tree(self, template, type_descriptor=None,
-                              trace=False, legacy=False):
+                              trace=False):
         """Build a tree of region extractors corresponding to the template."""
         basic_extractors = BaseExtractor.create(template.annotations)
         if trace:
             basic_extractors = TraceExtractor.apply(template, basic_extractors)
-        basic_extractors = ContainerExtractor.apply(template, basic_extractors,
-                                                    legacy=legacy)
+        basic_extractors = ContainerExtractor.apply(template, basic_extractors)
 
         item_containers, extractors = [], []
         for extractor in basic_extractors:
@@ -924,7 +979,7 @@ class SlybotIBLExtractor(InstanceBasedLearningExtractor):
         if not extractors:
             return TemplatePageMultiItemExtractor(template, item_containers)
         outer_container = ContainerExtractor(
-            extractors, template, legacy=True,
+            extractors, template,
             required_fields=template.extra_required_attrs)
         extractors = [outer_container]
         extractors.extend(item_containers)

--- a/slybot/slybot/plugins/scrapely_annotations/utils.py
+++ b/slybot/slybot/plugins/scrapely_annotations/utils.py
@@ -87,7 +87,6 @@ def _modify_tagids(source, add=True):
             output.append(serialize_tag(element))
         else:
             output.append(source.body[element.start:element.end])
-
     return ''.join(output)
 
 

--- a/slybot/slybot/spidermanager.py
+++ b/slybot/slybot/spidermanager.py
@@ -2,6 +2,9 @@ from __future__ import absolute_import
 import tempfile
 import shutil
 import atexit
+import logging
+
+import slybot
 
 from zipfile import ZipFile
 
@@ -19,6 +22,7 @@ class SlybotSpiderManager(object):
     implements(ISpiderManager)
 
     def __init__(self, datadir, spider_cls=None, settings=None, **kwargs):
+        logging.info('Slybot %s Spider', slybot.__version__)
         if settings is None:
             settings = get_project_settings()
         self.spider_cls = load_object(spider_cls) if spider_cls else IblSpider

--- a/slybot/slybot/tests/data/templates/autoevolution.json
+++ b/slybot/slybot/tests/data/templates/autoevolution.json
@@ -1,0 +1,437 @@
+{
+    "extractors": {},
+    "id": "f608-48fc-9420",
+    "name": "car",
+    "original_body": "<!DOCTYPE html>\n<html lang=\"en-us\">\n<head profile=\"http://www.w3.org/2005/10/profile\" id=\"head\" prefix=\"og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#\">\n<title>HONDA Civic 5 Doors (2005 - 2008)</title>\n<meta name=\"language\" content=\"en\"><meta name=\"robots\" content=\"noodp\">\n<meta name=\"description\" content=\"General information, engines and tech specifications for HONDA Civic 5 Doors (2005, 2006, 2007, 2008)\">\n<meta name=\"keywords\" content=\"HONDA, HONDA Civic 5 Doors, HONDA Civic 5 Doors (2005 - 2008), engines, specifications, specs, technical specs\">\n<meta property=\"fb:app_id\" content=\"111790708909959\">\n<meta property=\"og:type\" content=\"article\">\n<meta property=\"og:url\" content=\"http://www.autoevolution.com/cars/honda-civic-5-doors-2005.html\">\n<meta property=\"og:title\" content=\"HONDA Civic 5 Doors (2005 - 2008)\">\n<meta property=\"og:description\" content=\"In 2005 Honda introduced the eighth generation Civic, with a different approach for the European market compared to the American/Japa...\">\n<meta property=\"article:publisher\" content=\"https://www.facebook.com/autoevolution\">\n<meta property=\"og:site_name\" content=\"autoevolution\">\n<meta property=\"og:image\" content=\"http://s1.cdn.autoevolution.com/images/gallery/HONDACivic5Doors-888_1.jpg\">\n<meta property=\"twitter:card\" content=\"summary\">\n<meta property=\"twitter:site\" content=\"@_autoevolution_\">\n<meta property=\"twitter:creator\" content=\"@_autoevolution_\">\n<meta property=\"twitter:url\" content=\"http://www.autoevolution.com/cars/honda-civic-5-doors-2005.html\">\n<meta property=\"twitter:title\" content=\"HONDA Civic 5 Doors (2005 - 2008)\">\n<meta property=\"twitter:description\" content=\"In 2005 Honda introduced the eighth generation Civic, with a different approach for the European market compared to the American/Japa...\">\n<meta property=\"twitter:image\" content=\"http://s1.cdn.autoevolution.com/images/gallery/HONDACivic5Doors-888_1.jpg\">\n<link href=\"http://s1.cdn.autoevolution.com/_min/?g=cssblog&amp;v=2016_28\" rel=\"stylesheet\" type=\"text/css\">\n<!--[if IE]><link href=\"http://s1.cdn.autoevolution.com/_css/style_ie.css?v=1188\" rel=\"stylesheet\" type=\"text/css\"><![endif]-->\n<link rel=\"icon\" type=\"image/x-icon\" href=\"http://s1.cdn.autoevolution.com/_img/favicon.ico\"><link rel=\"mask-icon\" sizes=\"any\" href=\"http://s1.cdn.autoevolution.com/_img/aefavicon.svg\" color=\"#000000\">\n<link rel=\"apple-touch-icon\" sizes=\"57x57\" href=\"http://s1.cdn.autoevolution.com/_img/touch-icon-57.png\">\n<link rel=\"apple-touch-icon\" sizes=\"72x72\" href=\"http://s1.cdn.autoevolution.com/_img/touch-icon-72.png\">\n<link rel=\"apple-touch-icon\" sizes=\"114x114\" href=\"http://s1.cdn.autoevolution.com/_img/touch-icon-114.png\">\n<link rel=\"alternate\" type=\"application/rss+xml\" title=\"autoevolution news\" href=\"http://www.autoevolution.com/rss/backend.xml\">\n<link rel=\"publisher\" href=\"https://plus.google.com/+autoevolutioncom\">\n<link rel=\"canonical\" href=\"http://www.autoevolution.com/cars/honda-civic-5-doors-2005.html\">\n<script>\nwindow.google_analytics_uacct = \"UA-61277-6\";\n(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){\n(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','//www.google-analytics.com/analytics.js','ga');\nga('create', 'UA-61277-6', 'autoevolution.com');\nga('require', 'displayfeatures');\nga('send', 'pageview');\nvar gats_scrolled=0;\nsetTimeout(function(){if(!gats_scrolled){ gats_scrolled=1; ga('send','event','No-Bounce','Page-Read'); }}, 30000);\nsetTimeout(function(){window.addEventListener ? window.addEventListener('scroll', ga_scroll, false) : window.attachEvent('onScroll', ga_scroll)}, 5000);\nfunction ga_scroll(){ if(!gats_scrolled) { gats_scrolled=1; ga('send','event','No-Bounce','Scrolled'); }}\n</script>\n<script src=\"http://s1.cdn.autoevolution.com/_min/?g=js_jquery&amp;v=2016_16\"></script>\n\n<!-- BEGIN 33Across SiteCTRL Script -->\n<script type='text/javascript'>if(document.location.protocol=='http:'){ var Tynt=Tynt||[];Tynt.push('dzK18g1myr5ABnrkHcnlKl'); (function(){var h,s=document.createElement('script');s.src='http://cdn.tynt.com/ti.js'; h=document.getElementsByTagName('script')[0];h.parentNode.insertBefore(s,h);})();}</script>\n<!-- END 33Across SiteCTRL Script -->\n\n\n</head>\n<body id=\"body\" itemscope itemtype=\"http://schema.org/Organization\">\n\t<div class=\"header-bg\">\n\t\t<div class=\"header\" id=\"header\">\n\t\t\t\t\t\t<a class=\"logo logov\" href=\"http://www.autoevolution.com/\" alt=\"autoevolution\" title=\"autoevolution\" itemprop=\"url\">autoevolution</a>\n\t\t\t<div class=\"headermenu\">\n\t\t\t\t<a  href=\"http://www.autoevolution.com/news/\" title=\"Automotive news and rumors\">News</a>\n\t\t\t\t<a class=\"active\" href=\"http://www.autoevolution.com/cars/\" title=\"Car manufacturer and models database\">Cars</a>\n\t\t\t\t<a  href=\"http://www.autoevolution.com/moto/\" title=\"Motorcycle manufacturer and models database\">Moto</a>\n\t\t\t\t<a  href=\"http://www.autoevolution.com/reviews/\" title=\"Car reviews by autoevolution\">Reviews</a>\n\t\t\t\t<a  href=\"http://www.autoevolution.com/spyshots/\" title=\"Spyshots and car illustrations\">Spyshots</a>\n\t\t\t\t<a  id=\"green\" href=\"http://www.autoevolution.com/green/\" title=\"The greener side of the automotive industry\">Green</a>\n\t\t\t\t\t\t\t</div>\n\t\t\t<div class=\"searchbox\"><span class=\"glyph\">&#x2315;</span><form action=\"/search.php?t=news\" method=\"post\"><input type=\"text\" name=\"s\" value=\"Search here...\" onclick=\"if(this.value=='Search here...') this.value=''\" onblur=\"if(this.value=='') this.value='Search here...'\"></form></div>\n\t\t</div>\n\t</div>\n\t<div class=\"topbar-bg\">\n\t\t<div class=\"topbar topbar_home\" id=\"topbar\">\n\t\t\t<p class=\"boldd\">main topics:</p>\n\t\t\t<a href=\"http://www.autoevolution.com/editorial/\" title=\"Editorial\">EDITORIAL</a>\n\t\t\t<a href=\"http://www.autoevolution.com/coverstory/\" title=\"Coverstory\">COVERSTORY</a>\n\t\t\t<a href=\"http://www.autoevolution.com/auto-moto-shows/\" title=\"Auto Shows\">AUTO SHOWS</a>\n\t\t\t<a href=\"http://www.autoevolution.com/news/stars-cars/\" title=\"Stars & Cars\">STARS &amp; CARS</a>\n\t\t\t<a href=\"http://www.autoevolution.com/news/tuning/\" title=\"Tuning News\">TUNING</a>\n\t\t\t<a href=\"http://www.autoevolution.com/auto-guide/\" title=\"Auto Guides & How-Tos\">AUTO HOW-TO</a>\n\t\t\t<a href=\"http://www.autoevolution.com/bac/\" title=\"Blood Alcohol Concentration Calculator\">BAC CALCULATOR</a>\n\t\t\t<span class=\"bull\">&bull;</span>\n\t\t\t<a class=\"boldd col-bmw\" href=\"http://www.autoevolution.com/bmw-blog/\" title=\"BMW Blog\">BMW</a>\n\t\t\t<a class=\"boldd col-toyota\" href=\"http://www.autoevolution.com/toyota-blog/\" title=\"Toyota Blog\">TOYOTA</a>\n\t\t\t<a class=\"boldd col-mercedes\" href=\"http://www.autoevolution.com/mercedes-blog/\" title=\"Mercedes Blog\">MERCEDES</a>\n\t\t\t<span class=\"expander glyph jhrefb\" id=\"expander\" onclick=\"slidetop()\">... &#x25bc;</span>\n\t\t</div>\n\t\t<div class=\"topbar\" id=\"topbar2\">\n\t\t\t<p class=\"boldd\">don't miss:</p>\n\t\t\t<a href=\"http://www.autoevolution.com/newstag/pic+of+the+day/\" title=\"Photo of the Day Series\">PHOTO OF THE DAY</a>\n\t\t\t<a href=\"http://www.autoevolution.com/news/tech-toys\" title=\"Auto Gadgets & Toys\">TECH TOYS</A>\n\t\t\t<a href=\"http://www.autoevolution.com/news/safety/\" title=\"Safety News\">SAFETY</a>\n\t\t\t<a href=\"http://www.autoevolution.com/news/motorsport\" title=\"Motorsport\">MOTORSPORT</a>\n\t\t\t<a href=\"http://www.autoevolution.com/carfinder/\" title=\"Car Finder\">CAR FINDER</a>\n\t\t\t<a href=\"http://www.autoevolution.com/moto-how-to/\" title=\"Moto Guides & How-Tos\">MOTO HOW-TO</a>\n\t\t\t<a class=\"nopad\" href=\"http://www.autoevolution.com/auto-glossary/\" title=\"Glossary\">GLOSSARY</a>\n\t\t</div>\n\t</div>\n<div class=\"maincontent\">\n\t<div class=\"content fullsize\">\n\t\t<h1 class=\"nofloat\"><img class=\"nomgleft\" alt=\"HONDA\" title=\"HONDA\" src=\"http://s1.cdn.autoevolution.com/images/producers/honda-50.jpg\" width=\"32\" height=\"32\" /> HONDA Civic 5 Doors <span class=\"faded\">2005 - 2008</span></h1>\n\t\t\t\t<div style=\"font-size: 115%; margin-top:8px;\">\n\t\t<a href=\"http://www.autoevolution.com/\" title=\"autoevolution home\">Home</a>\n\t &gt; <a href=\"http://www.autoevolution.com/cars/\" title=\"Cars\">Cars</a>  &gt; <a href=\"http://www.autoevolution.com/honda/\" title=\"HONDA\">HONDA</a>  &gt; <a href=\"http://www.autoevolution.com/honda/civic-5-doors/\" title=\"Civic 5 Doors\">Civic 5 Doors</a>  &gt; <a href=\"http://www.autoevolution.com/cars/honda-civic-5-doors-2005.html\" title=\"Civic 5 Doors 2005 - 2008\">Civic 5 Doors 2005 - 2008</a> \t\t</div>\n\t\t\t<div class=\"brk\"></div>\n\n\t\t<div class=\"box leaderheight long ad\"><script async src=\"//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js\"></script><ins class=\"adsbygoogle\" style=\"display:inline-block;width:728px;height:90px\" data-ad-client=\"ca-pub-7668878252976156\" data-ad-slot=\"3944680237\"></ins><script>(adsbygoogle = window.adsbygoogle || []).push({});</script></div>\n\n\t\t<div class=\"modelbox\">\n\t\t\t<div class=\"newstext fr\">\n\t\t\t\t<strong class=\"intro\">In 2005 Honda introduced the eighth generation Civic, with a different approach for the European market compared to the American/Japanese market.</strong> A year after it presented the Civic Concept, the production version rolled out, marking a staggering and unprecedented resemblance between the two. The car introduced a new and unconventional design inside and out. With the focus clearly on looks, Honda tried to answer complains of boring design from the previous generation and develop a compact addressed to a younger consumer segment. The engines behind the new Civic are both fuel efficient and thrifty with a 1.4-liter i-DSI, a 1.8-liter i-VTEC petrol unit and a 2.2-liter i-CTDi diesel.\t\t\t\t<div class=\"sharebox half\">\n\t\t\t\t\t<span>share: &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>\n\t\t\t\t\t<a href=\"#\" onclick=\"window.open('https://www.facebook.com/sharer/sharer.php?u=http%3A%2F%2Fwww.autoevolution.com%2Fcars%2Fhonda-civic-5-doors-2005.html','', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=600,width=600'); return false;\" rel=\"nofollow\" title=\"Share this page on Facebook\" class=\"fb\"><span class=\"glyph\">&#xf083;</span> share</a>\n\t\t\t\t\t<a href=\"https://plus.google.com/share?url=http://www.autoevolution.com/cars/honda-civic-5-doors-2005.html\" rel=\"nofollow\" target=\"_blank\" title=\"Share this page on Google Plus\" class=\"gplus\" onclick=\"window.open(this.href, '', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=600,width=600'); return false;\"><span class=\"glyph\">&#xf086;</span> share</a>\n\t\t\t\t\t<a href=\"http://twitter.com/intent/tweet?related=_autoevolution_&via=_autoevolution_&text=&url=http%3A%2F%2Fwww.autoevolution.com%2Fcars%2Fhonda-civic-5-doors-2005.html\" target=\"_blank\" rel=\"nofollow\" title=\"Share this page on Twitter\" class=\"twitter\" onclick=\"window.open(this.href, '', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=600,width=600'); return false;\"><span class=\"glyph\">&#xf084;</span> tweet</a>\n\t\t\t\t</div>\n\t\t\t\t<p class=\"more-news mgtop11\"><b>see also: &nbsp;</b>\n\t\t\t\t\t<a href=\"http://s1.cdn.autoevolution.com/images/gallery/HONDACivic5Doors-888_1.jpg\" target=\"_blank\" onclick=\"return open_lght();\" title=\"HONDA Civic 5 Doors (2005 - 2008) photo gallery\">photo gallery</a>\t\t\t\t\t\t\t\t\t\t\t\t\t\t</p>\n\t\t\t</div>\n\n\t\t\t\t\t\t<div class=\"modelphoto modelphoto_wg fl\">\n\t\t\t\t<a title=\"HONDA Civic 5 Doors (2005 - 2008) photo gallery\" target=\"_blank\" onclick=\"return open_lght();\" href=\"http://s1.cdn.autoevolution.com/images/gallery/HONDACivic5Doors-888_1.jpg\"><img src=\"http://s1.cdn.autoevolution.com/images/models/HONDA_Civic-5-Doors-2005_main.jpg\" width=\"270\" height=\"180\" alt=\"HONDA Civic 5 Doors (2005 - 2008)\" title=\"HONDA Civic 5 Doors (2005 - 2008)\"></a>\n\t\t\t\t<span class=\"glyph magglass3 jhref\" onclick=\"open_lght()\">&#x2316;</span>\n\t\t\t\t<div class=\"glyph galtitle jhrefb\" onclick=\"open_lght()\">13 photos</div>\n\t\t\t</div>\n\t\t\t\n\t\t\t<div class=\"brk\"></div>\n\t\t</div>\n\n\t\t\t\t<h2 class=\"nofloat mgtop22\" id=\"engines\">Engines <img src=\"http://s1.cdn.autoevolution.com/_img/icon-engine.png\" align=\"absmiddle\" width=\"44\" height=\"28\" alt=\"engines\" hspace=\"5\" /></h2>\n\n\t\t<div style=\"font-size: 18px; line-height: 33px; height: 33px; text-transform: uppercase; margin-top: 22px;\" class=\"\" id=\"compare\">compare selected engine with:\n\t\t\t<select name=\"cmp1\" onchange=\"cmp_setbrand(this.value)\"><option value=\"0\">pick brand...</option><option value=\"10\" >ACURA</option><option value=\"11\" >ALFA ROMEO</option><option value=\"100\" >ARIEL</option><option value=\"12\" >ARO</option><option value=\"13\" >ASTON MARTIN</option><option value=\"14\" >AUDI</option><option value=\"15\" >BENTLEY</option><option value=\"16\" >BMW</option><option value=\"17\" >BRISTOL</option><option value=\"109\" >BUFORI</option><option value=\"19\" >BUGATTI</option><option value=\"20\" >BUICK</option><option value=\"21\" >CADILLAC</option><option value=\"101\" >CATERHAM</option><option value=\"22\" >CHEVROLET</option><option value=\"23\" >CHRYSLER</option><option value=\"24\" >CITROEN</option><option value=\"25\" >DACIA</option><option value=\"26\" >DAEWOO</option><option value=\"27\" >DAIHATSU</option><option value=\"112\" >DATSUN</option><option value=\"28\" >DMC</option><option value=\"29\" >DODGE</option><option value=\"91\" >DONKERVOORT</option><option value=\"113\" >DR MOTOR</option><option value=\"30\" >FERRARI</option><option value=\"31\" >FIAT</option><option value=\"104\" >FISKER</option><option value=\"32\" >FORD</option><option value=\"92\" >FSO</option><option value=\"103\" >GEELY</option><option value=\"33\" >GMC</option><option value=\"106\" >GTA Motor</option><option value=\"35\" >HINDUSTAN</option><option value=\"36\" >HOLDEN</option><option value=\"37\" >HONDA</option><option value=\"38\" >HUMMER</option><option value=\"39\" >HYUNDAI</option><option value=\"40\" >INFINITI</option><option value=\"41\" >ISUZU</option><option value=\"42\" >JAGUAR</option><option value=\"43\" >JEEP</option><option value=\"44\" >KIA</option><option value=\"99\" >KOENIGSEGG</option><option value=\"97\" >KTM</option><option value=\"45\" >LADA</option><option value=\"46\" >LAMBORGHINI</option><option value=\"48\" >LANCIA</option><option value=\"47\" >LAND ROVER</option><option value=\"49\" >LEXUS</option><option value=\"51\" >LINCOLN</option><option value=\"50\" >LOTUS</option><option value=\"107\" >Mahindra</option><option value=\"105\" >MARUSSIA</option><option value=\"93\" >MARUTI SUZUKI</option><option value=\"53\" >MASERATI</option><option value=\"54\" >MAYBACH</option><option value=\"52\" >MAZDA</option><option value=\"89\" >MCLAREN</option><option value=\"55\" >MERCEDES BENZ</option><option value=\"57\" >MERCURY</option><option value=\"56\" >MG</option><option value=\"58\" >MINI</option><option value=\"59\" >MITSUBISHI</option><option value=\"60\" >MORGAN</option><option value=\"61\" >NISSAN</option><option value=\"62\" >OLDSMOBILE</option><option value=\"63\" >OPEL</option><option value=\"67\" >PAGANI</option><option value=\"69\" >PANOZ</option><option value=\"114\" >PERODUA</option><option value=\"64\" >PEUGEOT</option><option value=\"65\" >PONTIAC</option><option value=\"66\" >PORSCHE</option><option value=\"68\" >PROTON</option><option value=\"110\" >QOROS</option><option value=\"108\" >RAM Trucks</option><option value=\"70\" >RENAULT</option><option value=\"71\" >ROLLS-ROYCE</option><option value=\"111\" >ROVER</option><option value=\"72\" >SAAB</option><option value=\"80\" >SALEEN</option><option value=\"94\" >SAMSUNG</option><option value=\"90\" >SANTANA</option><option value=\"73\" >SATURN</option><option value=\"75\" >SCION</option><option value=\"74\" >SEAT</option><option value=\"76\" >SKODA</option><option value=\"77\" >SMART</option><option value=\"79\" >SPYKER</option><option value=\"78\" >SSANGYONG</option><option value=\"81\" >SUBARU</option><option value=\"82\" >SUZUKI</option><option value=\"95\" >TATA MOTORS</option><option value=\"96\" >TESLA MOTORS</option><option value=\"83\" >TOYOTA</option><option value=\"85\" >TVR</option><option value=\"84\" >VAUXHALL</option><option value=\"86\" >VOLKSWAGEN</option><option value=\"87\" >VOLVO</option><option value=\"102\" >WIESMANN</option><option value=\"88\" >ZENDER</option></select>\n\t\t\t<span id=\"cmp2\"></span>\n\t\t\t<span id=\"cmp3\"></span>\n\t\t\t<span id=\"cmp4\"></span>\n\t\t\t<script type=\"text/javascript\">window.first_id = 0;</script>\n\t\t</div>\n\n\t\t<div class=\"enginesbox nobg\">\n\t\t\t<div class=\"fl enginesleft\">\n\t\t\t\t\t\t\t\t<h4>Gasoline engines</h4>\n\t\t\t\t\t<ul class=\"list\"><li id=\"li_eng_honda-civic-5-doors-2005-14-i-dsi\" class=\"ellip\" onclick=\"engine_show('eng_honda-civic-5-doors-2005-14-i-dsi'); document.getElementById('_wlts2a').contentDocument.location.reload(true);\" title=\"HONDA Civic 5 Doors 1.4 i-DSI 2005 - 2008\">1.4 i-DSI</li><li id=\"li_eng_honda-civic-5-doors-2005-18-i-vtec\" class=\"ellip\" onclick=\"engine_show('eng_honda-civic-5-doors-2005-18-i-vtec'); document.getElementById('_wlts2a').contentDocument.location.reload(true);\" title=\"HONDA Civic 5 Doors 1.8 i-VTEC 2005 - 2008\">1.8 i-VTEC</li></ul>\n\t\t\t\t\t\t\t\t\t<h4>Diesel engines</h4>\n\t\t\t\t\t<ul class=\"list\"><li id=\"li_eng_honda-civic-5-doors-2005-22-i-ctdi\" class=\"ellip\" onclick=\"engine_show('eng_honda-civic-5-doors-2005-22-i-ctdi'); document.getElementById('_wlts2a').contentDocument.location.reload(true);\" title=\"HONDA Civic 5 Doors 2.2 i-CTDi 2005 - 2008\">2.2 i-CTDi</li></ul>\n\t\t\t\t\t\t\t</div>\n\n\t\t\t<div class=\"fr enginesright posrel\">\n\t\t\t\t<div id=\"eng_honda-civic-5-doors-2005-14-i-dsi\" data-engid=\"2857\" class=\"engine-block\"><h3><span class=\"red2\">HONDA Civic 5 Doors 1.4 i-DSI</span> - technical specs</h3><div class=\"enginedata engine-inline\"><h3>engine specifications</h3><dl title=\"General Specs\" class=\"grspec\"><dt>Cylinders</dt><dd>L4 </dd><dt>Displacement</dt><dd>1339 cm3</dd><dt>Power</dt><dd>61 KW @ 5700 RPM<br/>83 HP @ 5700 RPM<br/>82 BHP @ 5700 RPM<dt>Torque</dt><dd>87.8 lb-ft @ 2800 RPM<br/>119 Nm @ 2800 RPM<dt>Fuel System</dt><dd>Multipoint Injection </dd><dt>Fuel</dt><dd>Gasoline </dd><dt>CO2 Emissions</dt><dd>139 g/km</dd><div class=\"brk\"></div></dl><h3>performance specifications</h3><dl title=\"Performance Specs\" ><dt>Top Speed</dt><dd>105.6 mph <b>OR</b> 170 km/h</dd><dt>Acceleration 0-62 Mph (0-100 kph)</dt><dd>14.6 s</dd><div class=\"brk\"></div></dl><h3>fuel consumption specifications</h3><dl title=\"Fuel Consumption Specs\" ><dt>City</dt><dd>30.9 mpg US <b>OR</b> 7.6 L/100Km</dd><dt>Highway</dt><dd>48 mpg US <b>OR</b> 4.9 L/100Km</dd><dt>Combined</dt><dd>39.9 mpg US <b>OR</b> 5.9 L/100Km</dd><div class=\"brk\"></div></dl><h3>transmission specifications</h3><dl title=\"Transmission Specs\" ><dt>Drive Type</dt><dd>Front Wheel Drive </dd><dt>Gearbox</dt><dd>Manual, 6 Speed </dd><div class=\"brk\"></div></dl><h3>brakes specifications</h3><dl title=\"Brakes Specs\" ><dt>Front</dt><dd>Ventilated Discs </dd><dt>Rear</dt><dd>Discs </dd><div class=\"brk\"></div></dl><h3>tires specifications</h3><dl title=\"Tires Specs\" ><dt>Tire Size</dt><dd>205/55R16 </dd><div class=\"brk\"></div></dl><h3>dimensions specifications</h3><dl title=\"Dimensions Specs\" ><dt>Length</dt><dd>167.3 in <b>OR</b> 4249 mm</dd><dt>Width</dt><dd>69.3 in <b>OR</b> 1760 mm</dd><dt>Height</dt><dd>57.5 in <b>OR</b> 1461 mm</dd><dt>Front/rear Track</dt><dd>59.1/59.4 in <b>OR</b> 1,501/1,509 mm</dd><dt>Wheelbase</dt><dd>103.9 in <b>OR</b> 2639 mm</dd><dt>Ground Clearance</dt><dd>- </dd><dt>Cargo Volume</dt><dd>17.1 cuFT <b>OR</b> 484 L</dd><dt>Cd</dt><dd>- </dd><div class=\"brk\"></div></dl><h3>weight specifications</h3><dl title=\"Weight Specs\" ><dt>Unladen Weight</dt><dd>2513.3 lbs <b>OR</b> 1140 kg</dd><dt>Gross Weight Limit</dt><dd>3637.6 lbs <b>OR</b> 1650 kg</dd><div class=\"brk\"></div></dl></div></div><div id=\"eng_honda-civic-5-doors-2005-18-i-vtec\" data-engid=\"10832\" class=\"engine-block\"><h3><span class=\"red2\">HONDA Civic 5 Doors 1.8 i-VTEC</span> - technical specs</h3><div class=\"enginedata engine-inline\"><h3>engine specifications</h3><dl title=\"General Specs\" class=\"grspec\"><dt>Cylinders</dt><dd>L4 </dd><dt>Displacement</dt><dd>1799 cm3</dd><dt>Power</dt><dd>103 KW @ 6300 RPM<br/>140 HP @ 6300 RPM<br/>138 BHP @ 6300 RPM<dt>Torque</dt><dd>128.3 lb-ft @ 4300 RPM<br/>174 Nm @ 4300 RPM<dt>Fuel System</dt><dd>Multipoint Injection </dd><dt>Fuel</dt><dd>Gasoline </dd><dt>CO2 Emissions</dt><dd>152 g/km</dd><div class=\"brk\"></div></dl><h3>performance specifications</h3><dl title=\"Performance Specs\" ><dt>Top Speed</dt><dd>127.4 mph <b>OR</b> 205 km/h</dd><dt>Acceleration 0-62 Mph (0-100 kph)</dt><dd>8.9 s</dd><div class=\"brk\"></div></dl><h3>fuel consumption specifications</h3><dl title=\"Fuel Consumption Specs\" ><dt>City</dt><dd>28.7 mpg US <b>OR</b> 8.2 L/100Km</dd><dt>Highway</dt><dd>45.2 mpg US <b>OR</b> 5.2 L/100Km</dd><dt>Combined</dt><dd>36.8 mpg US <b>OR</b> 6.4 L/100Km</dd><div class=\"brk\"></div></dl><h3>transmission specifications</h3><dl title=\"Transmission Specs\" ><dt>Drive Type</dt><dd>Front Wheel Drive </dd><dt>Gearbox</dt><dd>Manual, 6 Speed </dd><div class=\"brk\"></div></dl><h3>brakes specifications</h3><dl title=\"Brakes Specs\" ><dt>Front</dt><dd>Ventilated Discs </dd><dt>Rear</dt><dd>Discs </dd><div class=\"brk\"></div></dl><h3>tires specifications</h3><dl title=\"Tires Specs\" ><dt>Tire Size</dt><dd>205/55R16 </dd><div class=\"brk\"></div></dl><h3>dimensions specifications</h3><dl title=\"Dimensions Specs\" ><dt>Length</dt><dd>167.3 in <b>OR</b> 4249 mm</dd><dt>Width</dt><dd>69.3 in <b>OR</b> 1760 mm</dd><dt>Height</dt><dd>57.5 in <b>OR</b> 1461 mm</dd><dt>Front/rear Track</dt><dd>59.1/59.4 in <b>OR</b> 1,501/1,509 mm</dd><dt>Wheelbase</dt><dd>103.9 in <b>OR</b> 2639 mm</dd><dt>Ground Clearance</dt><dd>- </dd><dt>Cargo Volume</dt><dd>17.1 cuFT <b>OR</b> 484 L</dd><dt>Cd</dt><dd>- </dd><div class=\"brk\"></div></dl><h3>weight specifications</h3><dl title=\"Weight Specs\" ><dt>Unladen Weight</dt><dd>2568.4 lbs <b>OR</b> 1165 kg</dd><dt>Gross Weight Limit</dt><dd>3858.1 lbs <b>OR</b> 1750 kg</dd><div class=\"brk\"></div></dl></div></div><div id=\"eng_honda-civic-5-doors-2005-22-i-ctdi\" data-engid=\"10833\" class=\"engine-block\"><h3><span class=\"red2\">HONDA Civic 5 Doors 2.2 i-CTDi</span> - technical specs</h3><div class=\"enginedata engine-inline\"><h3>engine specifications</h3><dl title=\"General Specs\" class=\"grspec\"><dt>Cylinders</dt><dd>L4 </dd><dt>Displacement</dt><dd>2204 cm3</dd><dt>Power</dt><dd>103 KW @ 4000 RPM<br/>140 HP @ 4000 RPM<br/>138 BHP @ 4000 RPM<dt>Torque</dt><dd>250.8 lb-ft @ 2000 RPM<br/>340 Nm @ 2000 RPM<dt>Fuel System</dt><dd>Common Rail </dd><dt>Fuel</dt><dd>Diesel </dd><dt>CO2 Emissions</dt><dd>135 g/km</dd><div class=\"brk\"></div></dl><h3>performance specifications</h3><dl title=\"Performance Specs\" ><dt>Top Speed</dt><dd>127.4 mph <b>OR</b> 205 km/h</dd><dt>Acceleration 0-62 Mph (0-100 kph)</dt><dd>8.6 s</dd><div class=\"brk\"></div></dl><h3>fuel consumption specifications</h3><dl title=\"Fuel Consumption Specs\" ><dt>City</dt><dd>35.6 mpg US <b>OR</b> 6.6 L/100Km</dd><dt>Highway</dt><dd>54.7 mpg US <b>OR</b> 4.3 L/100Km</dd><dt>Combined</dt><dd>46.1 mpg US <b>OR</b> 5.1 L/100Km</dd><div class=\"brk\"></div></dl><h3>transmission specifications</h3><dl title=\"Transmission Specs\" ><dt>Drive Type</dt><dd>Front Wheel Drive </dd><dt>Gearbox</dt><dd>Manual, 6 Speed </dd><div class=\"brk\"></div></dl><h3>brakes specifications</h3><dl title=\"Brakes Specs\" ><dt>Front</dt><dd>Ventilated Discs </dd><dt>Rear</dt><dd>Discs </dd><div class=\"brk\"></div></dl><h3>tires specifications</h3><dl title=\"Tires Specs\" ><dt>Tire Size</dt><dd>205/55R16 </dd><div class=\"brk\"></div></dl><h3>dimensions specifications</h3><dl title=\"Dimensions Specs\" ><dt>Length</dt><dd>167.3 in <b>OR</b> 4249 mm</dd><dt>Width</dt><dd>69.3 in <b>OR</b> 1760 mm</dd><dt>Height</dt><dd>57.5 in <b>OR</b> 1461 mm</dd><dt>Front/rear Track</dt><dd>59.1/59.4 in <b>OR</b> 1,501/1,509 mm</dd><dt>Wheelbase</dt><dd>103.9 in <b>OR</b> 2639 mm</dd><dt>Ground Clearance</dt><dd>- </dd><dt>Cargo Volume</dt><dd>17.1 cuFT <b>OR</b> 484 L</dd><dt>Cd</dt><dd>- </dd><div class=\"brk\"></div></dl><h3>weight specifications</h3><dl title=\"Weight Specs\" ><dt>Unladen Weight</dt><dd>2914.5 lbs <b>OR</b> 1322 kg</dd><dt>Gross Weight Limit</dt><dd>4166.7 lbs <b>OR</b> 1890 kg</dd><div class=\"brk\"></div></dl></div></div>\t\t\t\t<div class=\"ad enginesrightad\" id=\"_wlts2\"><iframe id=\"_wlts2a\" src=\"/yd.php\" width=\"300\" height=\"250\" frameborder=\"0\" scrolling=\"no\"></iframe></div>\n\t\t\t</div>\n\n\t\t\t<div class=\"brk\"></div>\n\t\t</div>\n\t\t\n\t\t\n\t\t\t\t<h2 class=\"nofloat mgtop22\" id=\"photo_gallery\">Photo Gallery</h2>\n\t\t<div id=\"galleria_ds\">\n\t\t<div class=\"enginesbox\" style=\"padding:5px;\"><div class=\"photogal\" style=\"width:990px;\"><h4>exterior</h4><ul><div><a class=\"s_gallery\" target=\"_blank\" href=\"http://s1.cdn.autoevolution.com/images/gallery/HONDACivic5Doors-888_1.jpg\" title=\"HONDA Civic 5 Doors (2005 - 2008)\" id=\"aegal_0\"><img src=\"http://s1.cdn.autoevolution.com/images/gallery/thumbs/HONDACivic5Doors-thumbnail-888_1.jpg\" data-title=\"HONDA Civic 5 Doors (2005 - 2008)\" data-description=\"Photo credits: HONDA\" data-gidm=\"20538\" data-gidx=\"0\" height=\"60\" alt=\"HONDA Civic 5 Doors (2005 - 2008)\" /></a></div><div><a class=\"s_gallery\" target=\"_blank\" href=\"http://s1.cdn.autoevolution.com/images/gallery/HONDACivic5Doors-888_2.jpg\" title=\"HONDA Civic 5 Doors (2005 - 2008)\" id=\"aegal_1\"><img src=\"http://s1.cdn.autoevolution.com/images/gallery/thumbs/HONDACivic5Doors-thumbnail-888_2.jpg\" data-title=\"HONDA Civic 5 Doors (2005 - 2008)\" data-description=\"Photo credits: HONDA\" data-gidm=\"20539\" data-gidx=\"1\" height=\"60\" alt=\"HONDA Civic 5 Doors (2005 - 2008)\" /></a></div><div><a class=\"s_gallery\" target=\"_blank\" href=\"http://s1.cdn.autoevolution.com/images/gallery/HONDACivic5Doors-888_3.jpg\" title=\"HONDA Civic 5 Doors (2005 - 2008)\" id=\"aegal_2\"><img src=\"http://s1.cdn.autoevolution.com/images/gallery/thumbs/HONDACivic5Doors-thumbnail-888_3.jpg\" data-title=\"HONDA Civic 5 Doors (2005 - 2008)\" data-description=\"Photo credits: HONDA\" data-gidm=\"20540\" data-gidx=\"2\" height=\"60\" alt=\"HONDA Civic 5 Doors (2005 - 2008)\" /></a></div><div><a class=\"s_gallery\" target=\"_blank\" href=\"http://s1.cdn.autoevolution.com/images/gallery/HONDACivic5Doors-888_4.jpg\" title=\"HONDA Civic 5 Doors (2005 - 2008)\" id=\"aegal_3\"><img src=\"http://s1.cdn.autoevolution.com/images/gallery/thumbs/HONDACivic5Doors-thumbnail-888_4.jpg\" data-title=\"HONDA Civic 5 Doors (2005 - 2008)\" data-description=\"Photo credits: HONDA\" data-gidm=\"20541\" data-gidx=\"3\" height=\"60\" alt=\"HONDA Civic 5 Doors (2005 - 2008)\" /></a></div><div><a class=\"s_gallery\" target=\"_blank\" href=\"http://s1.cdn.autoevolution.com/images/gallery/HONDACivic5Doors-888_5.jpg\" title=\"HONDA Civic 5 Doors (2005 - 2008)\" id=\"aegal_4\"><img src=\"http://s1.cdn.autoevolution.com/images/gallery/thumbs/HONDACivic5Doors-thumbnail-888_5.jpg\" data-title=\"HONDA Civic 5 Doors (2005 - 2008)\" data-description=\"Photo credits: HONDA\" data-gidm=\"20542\" data-gidx=\"4\" height=\"60\" alt=\"HONDA Civic 5 Doors (2005 - 2008)\" /></a></div><div><a class=\"s_gallery\" target=\"_blank\" href=\"http://s1.cdn.autoevolution.com/images/gallery/HONDACivic5Doors-888_6.jpg\" title=\"HONDA Civic 5 Doors (2005 - 2008)\" id=\"aegal_5\"><img src=\"http://s1.cdn.autoevolution.com/images/gallery/thumbs/HONDACivic5Doors-thumbnail-888_6.jpg\" data-title=\"HONDA Civic 5 Doors (2005 - 2008)\" data-description=\"Photo credits: HONDA\" data-gidm=\"20543\" data-gidx=\"5\" height=\"60\" alt=\"HONDA Civic 5 Doors (2005 - 2008)\" /></a></div><div><a class=\"s_gallery\" target=\"_blank\" href=\"http://s1.cdn.autoevolution.com/images/gallery/HONDACivic5Doors-888_7.jpg\" title=\"HONDA Civic 5 Doors (2005 - 2008)\" id=\"aegal_6\"><img src=\"http://s1.cdn.autoevolution.com/images/gallery/thumbs/HONDACivic5Doors-thumbnail-888_7.jpg\" data-title=\"HONDA Civic 5 Doors (2005 - 2008)\" data-description=\"Photo credits: HONDA\" data-gidm=\"20544\" data-gidx=\"6\" height=\"60\" alt=\"HONDA Civic 5 Doors (2005 - 2008)\" /></a></div><div><a class=\"s_gallery\" target=\"_blank\" href=\"http://s1.cdn.autoevolution.com/images/gallery/HONDACivic5Doors-888_8.jpg\" title=\"HONDA Civic 5 Doors (2005 - 2008)\" id=\"aegal_7\"><img src=\"http://s1.cdn.autoevolution.com/images/gallery/thumbs/HONDACivic5Doors-thumbnail-888_8.jpg\" data-title=\"HONDA Civic 5 Doors (2005 - 2008)\" data-description=\"Photo credits: HONDA\" data-gidm=\"20545\" data-gidx=\"7\" height=\"60\" alt=\"HONDA Civic 5 Doors (2005 - 2008)\" /></a></div><div><a class=\"s_gallery\" target=\"_blank\" href=\"http://s1.cdn.autoevolution.com/images/gallery/HONDACivic5Doors-888_9.jpg\" title=\"HONDA Civic 5 Doors (2005 - 2008)\" id=\"aegal_8\"><img src=\"http://s1.cdn.autoevolution.com/images/gallery/thumbs/HONDACivic5Doors-thumbnail-888_9.jpg\" data-title=\"HONDA Civic 5 Doors (2005 - 2008)\" data-description=\"Photo credits: HONDA\" data-gidm=\"20546\" data-gidx=\"8\" height=\"60\" alt=\"HONDA Civic 5 Doors (2005 - 2008)\" /></a></div></ul></div><div class=\"brk\"></div></div><div class=\"enginesbox\" style=\"padding:5px;\"><div class=\"photogal\" style=\"width:990px;\"><h4>interior</h4><ul><div><a class=\"s_gallery\" target=\"_blank\" href=\"http://s1.cdn.autoevolution.com/images/gallery/HONDACivic5Doors-888_10.jpg\" title=\"HONDA Civic 5 Doors (2005 - 2008)\" id=\"aegal_9\"><img src=\"http://s1.cdn.autoevolution.com/images/gallery/thumbs/HONDACivic5Doors-thumbnail-888_10.jpg\" data-title=\"HONDA Civic 5 Doors (2005 - 2008)\" data-description=\"Photo credits: HONDA\" data-gidm=\"20547\" data-gidx=\"9\" height=\"60\" alt=\"HONDA Civic 5 Doors (2005 - 2008)\" /></a></div><div><a class=\"s_gallery\" target=\"_blank\" href=\"http://s1.cdn.autoevolution.com/images/gallery/HONDACivic5Doors-888_11.jpg\" title=\"HONDA Civic 5 Doors (2005 - 2008)\" id=\"aegal_10\"><img src=\"http://s1.cdn.autoevolution.com/images/gallery/thumbs/HONDACivic5Doors-thumbnail-888_11.jpg\" data-title=\"HONDA Civic 5 Doors (2005 - 2008)\" data-description=\"Photo credits: HONDA\" data-gidm=\"20548\" data-gidx=\"10\" height=\"60\" alt=\"HONDA Civic 5 Doors (2005 - 2008)\" /></a></div><div><a class=\"s_gallery\" target=\"_blank\" href=\"http://s1.cdn.autoevolution.com/images/gallery/HONDACivic5Doors-888_12.jpg\" title=\"HONDA Civic 5 Doors (2005 - 2008)\" id=\"aegal_11\"><img src=\"http://s1.cdn.autoevolution.com/images/gallery/thumbs/HONDACivic5Doors-thumbnail-888_12.jpg\" data-title=\"HONDA Civic 5 Doors (2005 - 2008)\" data-description=\"Photo credits: HONDA\" data-gidm=\"20549\" data-gidx=\"11\" height=\"60\" alt=\"HONDA Civic 5 Doors (2005 - 2008)\" /></a></div><div><a class=\"s_gallery\" target=\"_blank\" href=\"http://s1.cdn.autoevolution.com/images/gallery/HONDACivic5Doors-888_13.jpg\" title=\"HONDA Civic 5 Doors (2005 - 2008)\" id=\"aegal_12\"><img src=\"http://s1.cdn.autoevolution.com/images/gallery/thumbs/HONDACivic5Doors-thumbnail-888_13.jpg\" data-title=\"HONDA Civic 5 Doors (2005 - 2008)\" data-description=\"Photo credits: HONDA\" data-gidm=\"20550\" data-gidx=\"12\" height=\"60\" alt=\"HONDA Civic 5 Doors (2005 - 2008)\" /></a></div></ul></div><div class=\"brk\"></div></div>\t\t</div>\n\t\t<div class=\"brk\"></div>\n\t\t\n\t\t<div class=\"mgtop22\" id=\"prcontainer\"></div>\n\t</div>\n</div>\n<div class=\"brk\"></div>\n<div class=\"footer-bg\" id=\"footer\">\n\t<div class=\"footer\">\n\t\t<a href=\"http://www.autoevolution.com/\" title=\"autoevolution\" class=\"logof\">autoevolution</a>\n\t\t<ul>\n\t\t\t<li class=\"jhref\"  class=\"jhref\" onclick=\"ae_jjmp('aHR0cDovL3d3dy5hdXRvZXZvbHV0aW9uLmNvbS9jYXJzLw==')\"  title=\"Cars and Manufacturers Database\">cars</li>\n\t\t\t<li class=\"jhref\"  class=\"jhref\" onclick=\"ae_jjmp('aHR0cDovL3d3dy5hdXRvZXZvbHV0aW9uLmNvbS9tb3RvLw==')\"  title=\"Motorcycle and Manufacturers Database\">moto</li>\n\t\t\t<li class=\"jhref\"  class=\"jhref\" onclick=\"ae_jjmp('aHR0cDovL3d3dy5hdXRvZXZvbHV0aW9uLmNvbS9uZXdzLw==')\"  title=\"Latest Automotive News\">news</li>\n\t\t\t<li class=\"jhref\"  class=\"jhref\" onclick=\"ae_jjmp('aHR0cDovL3d3dy5hdXRvZXZvbHV0aW9uLmNvbS9yZXZpZXdzLw==')\"  title=\"autoevolution reviews\">reviews</li>\n\t\t\t<li class=\"jhref\"  class=\"jhref\" onclick=\"ae_jjmp('aHR0cDovL3d3dy5hdXRvZXZvbHV0aW9uLmNvbS9lZGl0b3JpYWwv')\"  title=\"Editorial\">editorial</li>\n\t\t\t<li class=\"jhref\"  class=\"jhref\" onclick=\"ae_jjmp('aHR0cDovL3d3dy5hdXRvZXZvbHV0aW9uLmNvbS9jb3ZlcnN0b3J5Lw==')\"  title=\"Coverstory\">coverstory</li>\n\t\t\t<li class=\"jhref\"  class=\"jhref\" onclick=\"ae_jjmp('aHR0cDovL3d3dy5hdXRvZXZvbHV0aW9uLmNvbS9hdXRvLWd1aWRlLw==')\"  title=\"Auto How-To\">auto how-to</li>\n\t\t\t<li class=\"jhref\"  class=\"jhref\" onclick=\"ae_jjmp('aHR0cDovL3d3dy5hdXRvZXZvbHV0aW9uLmNvbS9hdXRvLWdsb3NzYXJ5Lw==')\"  title=\"Technical Term Glossary\">glossary</li>\n\t\t\t<li class=\"jhref\"  class=\"jhref\" onclick=\"ae_jjmp('aHR0cDovL3d3dy5hdXRvZXZvbHV0aW9uLmNvbS9jYXJmaW5kZXIv')\"  title=\"Car Finder\">car finder</li>\n\t\t\t<li class=\"jhref\"  class=\"jhref\" onclick=\"ae_jjmp('aHR0cDovL3d3dy5hdXRvZXZvbHV0aW9uLmNvbS9yc3MtY2hhbm5lbHMv')\"  title=\"RSS Feeds\">rss</li>\n\t\t</ul>\n\t\t<p>\n\t\t\t&copy; 2008-2016 SoftNews NET. All rights reserved. <span itemprop=\"name\">autoevolution</span>&reg; and the autoevolution&reg; logo are registered trademarks.\n\t\t\t<a href=\"http://www.autoevolution.com/static/copyright.html\" rel=\"nofollow\" title=\"Copyright Information\">Copyright information</a>\n\t\t\t<a href=\"http://www.autoevolution.com/static/privacy.html\" rel=\"nofollow\" title=\"Privacy Policy\">Privacy Policy</a>\n\t\t\t<a href=\"http://www.autoevolution.com/static/terms.html\" rel=\"nofollow\" title=\"Terms of Use\">Terms of Use</a>\n\t\t\t<a href=\"http://www.autoevolution.com/contact/\" rel=\"nofollow\" title=\"Contact Us\">Contact Us</a>\n\t\t</p>\n\t</div>\n</div>\n\n<script src=\"http://s1.cdn.autoevolution.com/_min/?g=js_swipebox&amp;v=2016_21\"></script>\n<script>\n$(window).ready(function(){\n\twindow.aegal_cty = 'IE';\n\twindow.aegal_xdsect='cars';\n\twindow.aegal_imgr='cars';\n\t$('a.s_gallery, a.extragal').swipebox();\n\t$('.videospot a').swipebox();\n\tvar rgx=/^#*agal_/g; if(window.location.hash && rgx.test(window.location.hash)) $('#ae'+window.location.hash.replace('#', '').substr(1)).click();\n});\n</script>\n\n<script>\n\nvar eng_active='';\n$(window).ready(function(){\n\tvar rgx=/^#*aeng_/g;\n\tif(window.location.hash && rgx.test(window.location.hash)) engine_show(window.location.hash.replace('#', '').substr(1), true);\n\telse /*if(window.location.hash=='' || window.location.hash=='#')*/ engine_show_first(); });\n\n</script>\n\n\n\n\n<script>\nif($('#revtx')) { $('#revtx').on('focus', function (event) { NAV_OK = false; }); $('#revtx').on('blur', function (event) { NAV_OK = true; }); }\nif($('#sendtxt')) { $('#sendtxt').on('focus', function (event) { NAV_OK = false; }); $('#sendtxt').on('blur', function (event) { NAV_OK = true; }); }\n</script>\n<script>\n//$(document).ready(function(){ $(\".news-item img\").unveil(); $(\"#sidebar1 img\").unveil(); $(\"#tdnews-container img\").unveil(); $('.photogal img').unveil(); });\n$('#sidebar1 .box').on('mouseenter', function(){ $(this).find('img').each(function(i){ if($(this).attr('src') === undefined || $(this).attr('src') == '') return; $(this).attr('src', $(this).attr('src').replace('/images-bw/', '/images/')); }); }).on('mouseleave', function(){ $(this).find('img').each(function(i){ if($(this).attr('src') === undefined || $(this).attr('src') == '') return; $(this).attr('src', $(this).attr('src').replace('/images/', '/images-bw/')); }); });\nvar ae__apid='37';</script>\n\n<script>\n$(document).ready(function(){\n\tif(!$.cookie('ae_cookie_notif')){\n\t\t$('body').append('<div id=\"prajiturele\" style=\"z-index:1000; text-align: center; width: 100%; position: fixed; left: 0; top: 0; height: 22px; line-height: 22px; background-color: #aaaaaa;\">This site uses cookies to offer you a complete experience. <a href=\"http://www.autoevolution.com/static/privacy.html\" target=\"_blank\" title=\"Privacy and Cookies\"><u>Find out more</u></a> or <span class=\"jhrefb\" onclick=\"cookienotif_ack()\"><u>close</u> <b>(x)</b></span> this notification permanently.</div>');\n\t\t$('.header-bg').css('top', '+=22');$('body').css('padding-top', '+=22');$('.topbar-bg').css('top', '+=22');\n}});\n</script>\n\n\n<script>\nif(typeof adsbygoogle !== \"undefined\") {\n  window.addEventListener('load', function() {\n    if(typeof adsbygoogle.loaded === \"undefined\" && typeof ga !== \"undefined\") {\n      ga('send', 'event', 'AdSense', 'Ads blocked', { \"nonInteraction\": 1 });\n    }\n  }, false);\n}\n</script>\n\n</body>\n</html>\n",
+    "page_id": "f9595b583d2b1640b443722777d8225a9406bb80",
+    "page_type": "item",
+    "plugins": {
+        "annotations-plugin": {
+            "extracts": [
+                {
+                    "accept_selectors": [
+                        ".content"
+                    ],
+                    "annotations": {
+                        "#portia-content": "#dummy"
+                    },
+                    "container_id": null,
+                    "id": "3573-47a6-9c1e",
+                    "item_container": true,
+                    "repeated": false,
+                    "schema_id": "3e48-4f1d-a25a",
+                    "selector": ".content",
+                    "text-content": "#portia-content"
+                },
+                {
+                    "accept_selectors": [
+                        "#eng_honda-civic-5-doors-2005-14-i-dsi > .enginedata > .grspec > dd:nth-child(2)"
+                    ],
+                    "container_id": "3573-47a6-9c1e",
+                    "data": {
+                        "5663-4902-92ef": {
+                            "attribute": "content",
+                            "extractors": {},
+                            "field": "3d6c-406b-ada0",
+                            "required": false
+                        }
+                    },
+                    "id": "1ca6-4f38-b451",
+                    "selector": ".content > .enginesbox > .fr > div:nth-child(1) > .enginedata > .grspec > dd:nth-child(2)"
+                },
+                {
+                    "accept_selectors": [
+                        "#eng_honda-civic-5-doors-2005-14-i-dsi > .enginedata > .grspec > dd:nth-child(4)"
+                    ],
+                    "container_id": "3573-47a6-9c1e",
+                    "data": {
+                        "35da-4a50-873d": {
+                            "attribute": "content",
+                            "extractors": {},
+                            "field": "715d-44f0-8610",
+                            "required": false
+                        }
+                    },
+                    "id": "ac64-4442-bcaa",
+                    "selector": ".content > .enginesbox > .fr > div:nth-child(1) > .enginedata > .grspec > dd:nth-child(4)"
+                },
+                {
+                    "accept_selectors": [
+                        "#eng_honda-civic-5-doors-2005-14-i-dsi > .enginedata > .grspec > dd:nth-child(6)"
+                    ],
+                    "container_id": "3573-47a6-9c1e",
+                    "data": {
+                        "f84d-43b0-bbbd": {
+                            "attribute": "content",
+                            "extractors": {},
+                            "field": "adc7-4495-9093",
+                            "required": false
+                        }
+                    },
+                    "id": "6fcd-4273-9625",
+                    "selector": ".content > .enginesbox > .fr > div:nth-child(1) > .enginedata > .grspec > dd:nth-child(6)"
+                },
+                {
+                    "accept_selectors": [
+                        "#eng_honda-civic-5-doors-2005-14-i-dsi > .enginedata > .grspec > dd:nth-child(8)"
+                    ],
+                    "container_id": "3573-47a6-9c1e",
+                    "data": {
+                        "24da-47d8-b93b": {
+                            "attribute": "content",
+                            "extractors": {},
+                            "field": "280b-4069-bc68",
+                            "required": false
+                        }
+                    },
+                    "id": "1488-48f7-872c",
+                    "selector": ".content > .enginesbox > .fr > div:nth-child(1) > .enginedata > .grspec > dd:nth-child(8)"
+                },
+                {
+                    "accept_selectors": [
+                        "#eng_honda-civic-5-doors-2005-14-i-dsi > .enginedata > .grspec > dd:nth-child(10)"
+                    ],
+                    "container_id": "3573-47a6-9c1e",
+                    "data": {
+                        "a37e-4d0b-821a": {
+                            "attribute": "content",
+                            "extractors": {},
+                            "field": "f875-47f9-b433",
+                            "required": false
+                        }
+                    },
+                    "id": "712b-4ce9-aadb",
+                    "selector": ".content > .enginesbox > .fr > div:nth-child(1) > .enginedata > .grspec > dd:nth-child(10)"
+                },
+                {
+                    "accept_selectors": [
+                        "#eng_honda-civic-5-doors-2005-14-i-dsi > .enginedata > .grspec > dd:nth-child(12)"
+                    ],
+                    "container_id": "3573-47a6-9c1e",
+                    "data": {
+                        "c6ec-4034-854d": {
+                            "attribute": "content",
+                            "extractors": {},
+                            "field": "7b14-4c51-9d8d",
+                            "required": false
+                        }
+                    },
+                    "id": "fb80-48c1-bc5b",
+                    "selector": ".content > .enginesbox > .fr > div:nth-child(1) > .enginedata > .grspec > dd:nth-child(12)"
+                },
+                {
+                    "accept_selectors": [
+                        "#eng_honda-civic-5-doors-2005-14-i-dsi > .enginedata > .grspec > dd:nth-child(14)"
+                    ],
+                    "container_id": "3573-47a6-9c1e",
+                    "data": {
+                        "42d5-487f-bc4c": {
+                            "attribute": "content",
+                            "extractors": {},
+                            "field": "5c91-4055-9cd0",
+                            "required": false
+                        }
+                    },
+                    "id": "6729-4724-b57e",
+                    "selector": ".content > .enginesbox > .fr > div:nth-child(1) > .enginedata > .grspec > dd:nth-child(14)"
+                },
+                {
+                    "accept_selectors": [
+                        "#eng_honda-civic-5-doors-2005-14-i-dsi > .enginedata > dl:nth-child(4) > dd:nth-child(2)"
+                    ],
+                    "container_id": "3573-47a6-9c1e",
+                    "data": {
+                        "f633-4b45-b2a9": {
+                            "attribute": "content",
+                            "extractors": {},
+                            "field": "2237-4b60-94ff",
+                            "required": false
+                        }
+                    },
+                    "id": "303d-48a0-a8ff",
+                    "selector": ".content > .enginesbox > .fr > div:nth-child(1) > .enginedata > dl:nth-child(4) > dd:nth-child(2)"
+                },
+                {
+                    "accept_selectors": [
+                        "#eng_honda-civic-5-doors-2005-14-i-dsi > .enginedata > dl:nth-child(4) > dd:nth-child(4)"
+                    ],
+                    "container_id": "3573-47a6-9c1e",
+                    "data": {
+                        "13fe-404d-8cc2": {
+                            "attribute": "content",
+                            "extractors": {},
+                            "field": "b12f-4593-bb1e",
+                            "required": false
+                        }
+                    },
+                    "id": "12e0-445d-9cce",
+                    "selector": ".content > .enginesbox > .fr > div:nth-child(1) > .enginedata > dl:nth-child(4) > dd:nth-child(4)"
+                },
+                {
+                    "accept_selectors": [
+                        "#eng_honda-civic-5-doors-2005-14-i-dsi > .enginedata > dl:nth-child(6) > dd:nth-child(2)"
+                    ],
+                    "container_id": "3573-47a6-9c1e",
+                    "data": {
+                        "bad5-4796-8a59": {
+                            "attribute": "content",
+                            "extractors": {},
+                            "field": "1bc1-4326-958c",
+                            "required": false
+                        }
+                    },
+                    "id": "5ccb-4aa0-a9e9",
+                    "selector": ".content > .enginesbox > .fr > div:nth-child(1) > .enginedata > dl:nth-child(6) > dd:nth-child(2)"
+                },
+                {
+                    "accept_selectors": [
+                        "#eng_honda-civic-5-doors-2005-14-i-dsi > .enginedata > dl:nth-child(6) > dd:nth-child(4)"
+                    ],
+                    "container_id": "3573-47a6-9c1e",
+                    "data": {
+                        "c6db-4dc2-a7d5": {
+                            "attribute": "content",
+                            "extractors": {},
+                            "field": "809c-4921-aaec",
+                            "required": false
+                        }
+                    },
+                    "id": "a431-4d34-9839",
+                    "selector": ".content > .enginesbox > .fr > div:nth-child(1) > .enginedata > dl:nth-child(6) > dd:nth-child(4)"
+                },
+                {
+                    "accept_selectors": [
+                        "#eng_honda-civic-5-doors-2005-14-i-dsi > .enginedata > dl:nth-child(6) > dd:nth-child(6)"
+                    ],
+                    "container_id": "3573-47a6-9c1e",
+                    "data": {
+                        "0dfd-476d-9dc7": {
+                            "attribute": "content",
+                            "extractors": {},
+                            "field": "74ca-4687-a998",
+                            "required": false
+                        }
+                    },
+                    "id": "8fd4-45d2-a940",
+                    "selector": ".content > .enginesbox > .fr > div:nth-child(1) > .enginedata > dl:nth-child(6) > dd:nth-child(6)"
+                },
+                {
+                    "accept_selectors": [
+                        "#eng_honda-civic-5-doors-2005-14-i-dsi > .enginedata > dl:nth-child(12) > dd"
+                    ],
+                    "container_id": "3573-47a6-9c1e",
+                    "data": {
+                        "1dc7-44cc-8238": {
+                            "attribute": "content",
+                            "extractors": {},
+                            "field": "de5d-4a74-bbbe",
+                            "required": false
+                        }
+                    },
+                    "id": "886e-434b-b7cf",
+                    "selector": ".content > .enginesbox > .fr > div:nth-child(1) > .enginedata > dl:nth-child(12) > dd"
+                },
+                {
+                    "accept_selectors": [
+                        "#eng_honda-civic-5-doors-2005-14-i-dsi > .enginedata > dl:nth-child(14) > dd:nth-child(2)"
+                    ],
+                    "container_id": "3573-47a6-9c1e",
+                    "data": {
+                        "3dc6-43c1-ae78": {
+                            "attribute": "content",
+                            "extractors": {},
+                            "field": "ae56-4514-979d",
+                            "required": false
+                        }
+                    },
+                    "id": "afb8-4b73-a408",
+                    "selector": ".content > .enginesbox > .fr > div:nth-child(1) > .enginedata > dl:nth-child(14) > dd:nth-child(2)"
+                },
+                {
+                    "accept_selectors": [
+                        "#eng_honda-civic-5-doors-2005-14-i-dsi > .enginedata > dl:nth-child(14) > dd:nth-child(4)"
+                    ],
+                    "container_id": "3573-47a6-9c1e",
+                    "data": {
+                        "ea8c-446b-a40e": {
+                            "attribute": "content",
+                            "extractors": {},
+                            "field": "15f8-456a-b398",
+                            "required": false
+                        }
+                    },
+                    "id": "5569-4726-9dce",
+                    "selector": ".content > .enginesbox > .fr > div:nth-child(1) > .enginedata > dl:nth-child(14) > dd:nth-child(4)"
+                },
+                {
+                    "accept_selectors": [
+                        "#eng_honda-civic-5-doors-2005-14-i-dsi > .enginedata > dl:nth-child(14) > dd:nth-child(6)"
+                    ],
+                    "container_id": "3573-47a6-9c1e",
+                    "data": {
+                        "606e-4a53-a71a": {
+                            "attribute": "content",
+                            "extractors": {},
+                            "field": "81d2-4e34-afce",
+                            "required": false
+                        }
+                    },
+                    "id": "bb8b-432a-9a83",
+                    "selector": ".content > .enginesbox > .fr > div:nth-child(1) > .enginedata > dl:nth-child(14) > dd:nth-child(6)"
+                },
+                {
+                    "accept_selectors": [
+                        "#eng_honda-civic-5-doors-2005-14-i-dsi > .enginedata > dl:nth-child(14) > dd:nth-child(8)"
+                    ],
+                    "container_id": "3573-47a6-9c1e",
+                    "data": {
+                        "c334-49ad-b939": {
+                            "attribute": "content",
+                            "extractors": {},
+                            "field": "3848-45fc-8bbd",
+                            "required": false
+                        }
+                    },
+                    "id": "1347-4b1f-999e",
+                    "selector": ".content > .enginesbox > .fr > div:nth-child(1) > .enginedata > dl:nth-child(14) > dd:nth-child(8)"
+                },
+                {
+                    "accept_selectors": [
+                        "#eng_honda-civic-5-doors-2005-14-i-dsi > .enginedata > dl:nth-child(14) > dd:nth-child(10)"
+                    ],
+                    "container_id": "3573-47a6-9c1e",
+                    "data": {
+                        "32d0-4928-8163": {
+                            "attribute": "content",
+                            "extractors": {},
+                            "field": "c151-43ac-a996",
+                            "required": false
+                        }
+                    },
+                    "id": "4e9b-48eb-9d3d",
+                    "selector": ".content > .enginesbox > .fr > div:nth-child(1) > .enginedata > dl:nth-child(14) > dd:nth-child(10)"
+                },
+                {
+                    "accept_selectors": [
+                        "#eng_honda-civic-5-doors-2005-14-i-dsi > .enginedata > dl:nth-child(14) > dd:nth-child(12)"
+                    ],
+                    "container_id": "3573-47a6-9c1e",
+                    "data": {
+                        "ce45-411d-a244": {
+                            "attribute": "content",
+                            "extractors": {},
+                            "field": "edc5-44d4-8a37",
+                            "required": false
+                        }
+                    },
+                    "id": "be26-4d19-95d5",
+                    "selector": ".content > .enginesbox > .fr > div:nth-child(1) > .enginedata > dl:nth-child(14) > dd:nth-child(12)"
+                },
+                {
+                    "accept_selectors": [
+                        "#eng_honda-civic-5-doors-2005-14-i-dsi > .enginedata > dl:nth-child(14) > dd:nth-child(14)"
+                    ],
+                    "container_id": "3573-47a6-9c1e",
+                    "data": {
+                        "b56c-4062-bbed": {
+                            "attribute": "content",
+                            "extractors": {},
+                            "field": "97df-4068-b152",
+                            "required": false
+                        }
+                    },
+                    "id": "e334-4bff-87d5",
+                    "selector": ".content > .enginesbox > .fr > div:nth-child(1) > .enginedata > dl:nth-child(14) > dd:nth-child(14)"
+                },
+                {
+                    "accept_selectors": [
+                        "#eng_honda-civic-5-doors-2005-14-i-dsi > .enginedata > dl:nth-child(16) > dd:nth-child(2)"
+                    ],
+                    "container_id": "3573-47a6-9c1e",
+                    "data": {
+                        "1a1f-4d4c-ab95": {
+                            "attribute": "content",
+                            "extractors": {},
+                            "field": "eb01-487c-aabc",
+                            "required": false
+                        }
+                    },
+                    "id": "901f-43ed-abf2",
+                    "selector": ".content > .enginesbox > .fr > div:nth-child(1) > .enginedata > dl:nth-child(16) > dd:nth-child(2)"
+                },
+                {
+                    "accept_selectors": [
+                        "#eng_honda-civic-5-doors-2005-14-i-dsi > .enginedata > dl:nth-child(16) > dd:nth-child(4)"
+                    ],
+                    "container_id": "3573-47a6-9c1e",
+                    "data": {
+                        "b89f-47ed-a5ce": {
+                            "attribute": "content",
+                            "extractors": {},
+                            "field": "cb72-40f4-be48",
+                            "required": false
+                        }
+                    },
+                    "id": "a182-4128-95e2",
+                    "selector": ".content > .enginesbox > .fr > div:nth-child(1) > .enginedata > dl:nth-child(16) > dd:nth-child(4)"
+                },
+                {
+                    "accept_selectors": [
+                        ".modelphoto > a > img"
+                    ],
+                    "container_id": "3573-47a6-9c1e",
+                    "data": {
+                        "e246-499f-8ca9": {
+                            "attribute": "src",
+                            "extractors": {},
+                            "field": "5a2c-4dde-a064",
+                            "required": false
+                        }
+                    },
+                    "id": "e680-4782-9973",
+                    "selector": ".content > .modelbox > .modelphoto > a > img"
+                },
+                {
+                    "accept_selectors": [
+                        ".newstext"
+                    ],
+                    "container_id": "3573-47a6-9c1e",
+                    "data": {
+                        "43ea-4e95-9eea": {
+                            "attribute": "content",
+                            "extractors": {},
+                            "field": "bf29-49d0-8d32",
+                            "required": false
+                        }
+                    },
+                    "id": "cfeb-4ede-8028",
+                    "selector": ".content > .modelbox > .newstext"
+                },
+                {
+                    "accept_selectors": [
+                        "#li_eng_honda-civic-5-doors-2005-14-i-dsi",
+                        "#li_eng_honda-civic-5-doors-2005-18-i-vtec",
+                        "#li_eng_honda-civic-5-doors-2005-22-i-ctdi"
+                    ],
+                    "container_id": "3573-47a6-9c1e",
+                    "data": {
+                        "d036-4600-a8e2": {
+                            "attribute": "content",
+                            "extractors": {},
+                            "field": "2dc2-45d8-9bfc",
+                            "required": false
+                        }
+                    },
+                    "id": "1cd2-473f-9c04",
+                    "repeated": true,
+                    "selection_mode": "auto",
+                    "selector": ".content > .enginesbox > .fl > .list > .ellip"
+                }
+            ]
+        }
+    },
+    "scrapes": "3e48-4f1d-a25a",
+    "spider": "www.autoevolution.com",
+    "url": "http://www.autoevolution.com/cars/honda-civic-5-doors-2005.html#aeng_honda-civic-5-doors-2005-14-i-dsi",
+    "version": "0.13.0b20"
+}

--- a/slybot/slybot/tests/data/templates/so_annotations.json
+++ b/slybot/slybot/tests/data/templates/so_annotations.json
@@ -1,0 +1,151 @@
+{
+    "annos": [
+        {
+            "container_id": "5b7c-402c-9d4c", 
+            "data": {
+                "3310-4b70-85aa": {
+                    "attribute": "content", 
+                    "extractors": {}, 
+                    "field": "770d-4a6e-b910", 
+                    "id": "ee47-4ea0-a374|3310-4b70-85aa", 
+                    "required": false
+                }
+            }, 
+            "id": "ee47-4ea0-a374", 
+            "selector": ".question-summary > .summary > .started > .started-link"
+        }, 
+        {
+            "annotations": {
+                "#portia-content": "#dummy"
+            }, 
+            "container_id": "5b7c-402c-9d4c#parent", 
+            "id": "5b7c-402c-9d4c", 
+            "item_container": true, 
+            "repeated": true, 
+            "schema_id": "bb14-43b6-9040", 
+            "selector": ".question-summary", 
+            "siblings": 0, 
+            "text-content": "#portia-content"
+        }, 
+        {
+            "container_id": "5b7c-402c-9d4c", 
+            "data": {
+                "24f1-443b-b7d5": {
+                    "attribute": "content", 
+                    "extractors": {}, 
+                    "field": "5249-41c5-b481", 
+                    "id": "58f4-40ba-9b22|24f1-443b-b7d5", 
+                    "required": false
+                }
+            }, 
+            "id": "58f4-40ba-9b22", 
+            "selector": ".question-summary > .summary > h3 > .question-hyperlink"
+        }, 
+        {
+            "container_id": "5b7c-402c-9d4c", 
+            "data": {
+                "9574-4c8e-bfb5": {
+                    "attribute": "content", 
+                    "extractors": {}, 
+                    "field": "93b0-4236-94b0", 
+                    "id": "9df6-4251-a94e|9574-4c8e-bfb5", 
+                    "required": false
+                }
+            }, 
+            "id": "9df6-4251-a94e", 
+            "repeated": true, 
+            "selection_mode": "auto", 
+            "selector": "#question-mini-list > div:nth-child(1) > .summary > .tags > .post-tag"
+        }, 
+        {
+            "annotations": {
+                "#portia-content": "#dummy"
+            }, 
+            "container_id": null, 
+            "id": "5b7c-402c-9d4c#parent", 
+            "item_container": true, 
+            "schema_id": "bb14-43b6-9040", 
+            "selector": "#qlist-wrapper", 
+            "siblings": 0, 
+            "text-content": "#portia-content"
+        }
+    ], 
+    "items": {
+        "bb14-43b6-9040": {
+            "fields": {
+                "5249-41c5-b481": {
+                    "name": "title", 
+                    "required": 0, 
+                    "type": "text", 
+                    "vary": 0
+                }, 
+                "770d-4a6e-b910": {
+                    "name": "answered", 
+                    "required": 0, 
+                    "type": "text", 
+                    "vary": 0
+                }, 
+                "93b0-4236-94b0": {
+                    "name": "tags", 
+                    "required": 0, 
+                    "type": "text", 
+                    "vary": 0
+                }
+            }, 
+            "name": "question"
+        }
+    }, 
+    "results": [
+        {
+            "_index": 1, 
+            "_template": "507f520c3bf361f4c5cd55c44307a271bccb2218", 
+            "_type": "question", 
+            "answered": [
+                "asked 51 secs ago"
+            ], 
+            "tags": [
+                "jquery", 
+                "twitter-bootstrap", 
+                "navbar", 
+                "sticky"
+            ], 
+            "title": [
+                "Bootstrap navbar doesn't open - mobile view"
+            ], 
+            "url": "http://url"
+        }, 
+        {
+            "_index": 53, 
+            "_template": "507f520c3bf361f4c5cd55c44307a271bccb2218", 
+            "_type": "question", 
+            "answered": [
+                "modified 9 mins ago"
+            ], 
+            "tags": [
+                "javascript"
+            ], 
+            "title": [
+                "Export to Excel issue in Chrome and Firefox"
+            ], 
+            "url": "http://url"
+        }, 
+        {
+            "_index": 96, 
+            "_template": "507f520c3bf361f4c5cd55c44307a271bccb2218", 
+            "_type": "question", 
+            "answered": [
+                "asked 1 hour ago"
+            ], 
+            "tags": [
+                "python", 
+                "cassandra", 
+                "apache-spark", 
+                "ipython-notebook"
+            ], 
+            "title": [
+                "iPython + Spark + Cassandra - Py4JJavaError and How to connect to Cassandra from Spark?"
+            ], 
+            "url": "http://url"
+        }
+    ]
+}

--- a/slybot/slybot/tests/data/templates/xceed.json
+++ b/slybot/slybot/tests/data/templates/xceed.json
@@ -190,6 +190,24 @@
             "url": "http://url"
         }, 
         {
+            "_index": 5,
+            "_template": "ec891c9df77d09298c0f44f7973af3d5d4adc1e5",
+            "_type": "ticket",
+            "date": [
+                "Sales end: Jun 10, 23:45pm"
+            ],
+            "includes": [
+                "Prive\u00e9 on the Backstage for 5 people - 1 bottle inc. + soft drinks"
+            ],
+            "price": [
+                "230.00"
+            ],
+            "type": [
+                "Bottle Service"
+            ],
+            "url": "http://url"
+        }, 
+        {
             "_template": "ec891c9df77d09298c0f44f7973af3d5d4adc1e5", 
             "_type": "venue", 
             "address": [


### PR DESCRIPTION
Extract repeated lists of values
Container can only extract a single item unless it wraps a repeated container
Better handle cases where not all repeated items have all fields
Fixed printing error with BaseExtractor
Removed legacy support (legacy now uses scrapely.InstanceBasedLearningExtractor)
Log slybot version when using spidermanager