### PR TITLE
PORTIA-551 JobQ integration with Portia

### DIFF
--- a/portiaui/app/components/jobq-badge.js
+++ b/portiaui/app/components/jobq-badge.js
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+const { computed } = Ember;
+
+export default Ember.Component.extend({
+    jobQ: Ember.inject.service(),
+
+    jobs: computed.alias('jobQ.jobs'),
+
+    jobCount: computed('jobs.count', function() {
+        return this.get('jobs').countForSpider(this.get('spider.id'));
+    }),
+
+    isActive: computed.gt('jobCount', 0),
+
+    badgeStyle: computed('jobCount', function() {
+        return Ember.String.htmlSafe('background-color: #d9534f');
+    })
+});

--- a/portiaui/app/components/list-item-icon.js
+++ b/portiaui/app/components/list-item-icon.js
@@ -1,5 +1,7 @@
 import IconButton from './icon-button';
 
 export default IconButton.extend({
-    classNames: ['list-item-icon']
+    classNames: ['list-item-icon'],
+    classNameBindings: ['hasIndent'],
+    hasIndent: false
 });

--- a/portiaui/app/components/project-structure-listing.js
+++ b/portiaui/app/components/project-structure-listing.js
@@ -1,9 +1,11 @@
 import Ember from 'ember';
+const { computed } = Ember;
 import {computedCanAddSpider} from '../services/dispatcher';
 
 export default Ember.Component.extend({
     browser: Ember.inject.service(),
     dispatcher: Ember.inject.service(),
+    jobQ: Ember.inject.service(),
     uiState: Ember.inject.service(),
     notificationManager: Ember.inject.service(),
     routing: Ember.inject.service('-routing'),
@@ -14,7 +16,19 @@ export default Ember.Component.extend({
     currentSpider: Ember.computed.readOnly('uiState.models.spider'),
     currentSchema: Ember.computed.readOnly('uiState.models.schema'),
 
-    addSpiderTooltipText: Ember.computed('canAddSpider', {
+    jobCount: computed.alias('jobQ.jobs.count'),
+    spiderJobs: computed('jobCount', 'currentSpider', function() {
+        return this.get('jobQ.jobs').countForSpider();
+    }),
+    showJobs: computed('spiderJobs', 'routing.currentRouteName', function() {
+        return this.get('spiderJobs') > 0 && this.get('routing.currentRouteName').includes('spider');
+    }),
+    jobMessage: computed('spiderJobs', function() {
+        let isPlural = this.get('spiderJobs') > 1;
+        return `${this.get('spiderJobs')} job${isPlural ? 's' : ''} running`;
+    }),
+
+    addSpiderTooltipText: computed('canAddSpider', {
         get() {
             if (this.get('canAddSpider')) {
                 return 'Create a new Spider';

--- a/portiaui/app/helpers/has-job.js
+++ b/portiaui/app/helpers/has-job.js
@@ -1,0 +1,14 @@
+import Ember from 'ember';
+
+export default Ember.Helper.extend({
+    jobQ: Ember.inject.service(),
+
+    onJobCountChange: Ember.observer('jobQ.jobs.count', function() {
+        this.recompute();
+    }),
+
+    compute(params) {
+        const spider = params[0];
+        return this.get('jobQ.jobs').countForSpider(spider.get('id')) > 0;
+    }
+});

--- a/portiaui/app/routes/projects/project.js
+++ b/portiaui/app/routes/projects/project.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
     browser: Ember.inject.service(),
+    jobQ: Ember.inject.service(),
 
     model(params) {
         return this.store.findRecord('project', params.project_id);
@@ -24,6 +25,9 @@ export default Ember.Route.extend({
 
     setupController(controller, model) {
         this._super(controller, model);
+
+        this.get('jobQ').start(model.get('id'));
+
         controller.set('projects', this.controllerFor('projects'));
     },
 

--- a/portiaui/app/routes/projects/project/spider.js
+++ b/portiaui/app/routes/projects/project/spider.js
@@ -1,24 +1,27 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+    jobQ: Ember.inject.service(),
     browser: Ember.inject.service(),
 
     model(params) {
         return this.store.queryRecord('spider', {
             id: params.spider_id,
-            project_id: this.modelFor('projects.project').get('id')
+            project_id: this.projectId()
         });
     },
 
     afterModel(model) {
         return this.store.query('sample', {
-            spider_project_id: this.modelFor('projects.project').get('id'),
+            spider_project_id: this.projectId(),
             spider_id: model.get('id')
         });
     },
 
-    setupController(controller) {
+    setupController(controller, model) {
         this._super(...arguments);
+
+        this.get('jobQ').start(this.projectId(), model.get('id'));
         Ember.run.next(function () {
             controller.activate();
         });
@@ -31,6 +34,10 @@ export default Ember.Route.extend({
                 controller.activate();
             }
         });
+    },
+
+    projectId() {
+        return this.modelFor('projects.project').get('id');
     },
 
     renderTemplate() {

--- a/portiaui/app/services/job-q.js
+++ b/portiaui/app/services/job-q.js
@@ -1,0 +1,58 @@
+import Ember from 'ember';
+const { run } = Ember;
+
+const Jobs = Ember.Object.extend({
+    endpoint() {
+        return `http://storage.scrapinghub.com/jobq/${this.get('projectId')}/` +
+               `summary/running?apikey=${cookie.get('apikey')}`;
+    },
+
+    countForSpider(spider) {
+        let filterSpider = spider || this.get('currentSpider');
+        return this.get('data').filterBy('spider', filterSpider).length;
+    },
+
+    update(response) {
+        this.set('data', response.summary);
+        this.set('count', response.count);
+    }
+});
+
+export default Ember.Service.extend({
+    ajax: Ember.inject.service(),
+
+    timer: null,
+    interval: 10000,
+    jobs: Jobs.create({ count: 0, data: [] }),
+
+    start(projectId, currentSpider, interval) {
+        this.stop();
+
+        this.set('jobs.currentSpider', currentSpider);
+        this.set('jobs.projectId', projectId);
+        this.queryEndpoint();
+
+        this.set('timer', this.schedule(this.queryEndpoint, interval));
+    },
+
+    queryEndpoint() {
+        const jobs = this.get('jobs');
+        this.get('ajax').request(jobs.endpoint()).then((data) => {
+            jobs.update(data[0]);
+        }).catch(() => {});
+    },
+
+    stop() {
+        if (this.get('timer')) {
+            run.cancel(this.get('timer'));
+        }
+    },
+
+    schedule(f, interval) {
+        const time = interval || this.get('interval');
+        return run.later(() => {
+            f.apply(this);
+            this.set('timer', this.schedule(f, interval));
+        }, time);
+    }
+});

--- a/portiaui/app/services/job-q.js
+++ b/portiaui/app/services/job-q.js
@@ -3,7 +3,7 @@ const { run } = Ember;
 
 const Jobs = Ember.Object.extend({
     endpoint() {
-        return `http://storage.scrapinghub.com/jobq/${this.get('projectId')}/` +
+        return `https://storage.scrapinghub.com/jobq/${this.get('projectId')}/` +
                `summary/running?apikey=${cookie.get('apikey')}`;
     },
 

--- a/portiaui/app/styles/app.scss
+++ b/portiaui/app/styles/app.scss
@@ -62,6 +62,8 @@
 @import "templates/projects";
 @import "templates/browsers";
 
+@import "services/jobq";
+
 @import "components/animation-container";
 @import "components/browser-iframe";
 @import "components/browser-view-port";

--- a/portiaui/app/styles/components/list-item-badge.scss
+++ b/portiaui/app/styles/components/list-item-badge.scss
@@ -1,6 +1,6 @@
 .list-item-badge {
     display: inline-block;
-    flex: 0 0 26px;
+    flex: 0 0 20px;
     text-align: center;
 
     .badge {
@@ -13,5 +13,9 @@
         display: inline-block;
         margin: 0 -1000%;
         white-space: nowrap;
+    }
+
+    .has-sm-indent {
+        margin-left: 10px;
     }
 }

--- a/portiaui/app/styles/components/list-item-icon.scss
+++ b/portiaui/app/styles/components/list-item-icon.scss
@@ -12,6 +12,10 @@
         }
     }
 
+    &.has-indent {
+      margin-left: 20px;
+    }
+
     .tree-list-item-content & {
         height: $tree-list-row-height;
         line-height: $tree-list-row-height;

--- a/portiaui/app/styles/services/jobq.scss
+++ b/portiaui/app/styles/services/jobq.scss
@@ -1,0 +1,10 @@
+.jobq-message {
+    color: white;
+    background-color: $brand-danger;
+    margin: 5px 0 0 10px;
+    padding: 0 10px;
+    font-size: 0.9em;
+    height: 20px;
+    line-height: 20px;
+    text-transform: none;
+}

--- a/portiaui/app/templates/components/data-structure-annotations.hbs
+++ b/portiaui/app/templates/components/data-structure-annotations.hbs
@@ -6,8 +6,12 @@
             {{#if (eq annotation.constructor.modelName "annotation")}}
                 {{#tree-list-item onMouseEnter=(action 'enterAnnotation' annotation) onMouseLeave=(action 'leaveAnnotation' item) as |options|}}
                     {{#link-to 'projects.project.spider.sample.data.annotation' annotation}}
+                        {{list-item-badge
+                          value=(or annotation.elements.length 0)
+                          color=(array-get annotationColors annotation.orderedIndex)
+                          badgeClass='has-sm-indent'
+                        }}
                         {{list-item-icon icon=annotation.type}}
-                        {{list-item-badge value=(or annotation.elements.length 0) color=(array-get annotationColors annotation.orderedIndex)}}
                         {{list-item-annotation-field annotation=annotation selecting=(mut annotation.new)}}
                         {{#list-item-field-type field=annotation.field}}
                             Change type of selected field

--- a/portiaui/app/templates/components/data-structure-listing.hbs
+++ b/portiaui/app/templates/components/data-structure-listing.hbs
@@ -10,8 +10,8 @@
                 {{#unless item.itemAnnotation.parent}}
                     {{#data-structure-annotations sample=sample item=item annotationColors=annotationColors}}
                         {{#link-to 'projects.project.spider.sample.data.item' item}}
-                            {{list-item-icon icon='schema'}}
                             {{list-item-badge value=(or item.itemAnnotation.elements.length 0)}}
+                            {{list-item-icon icon='schema'}}
                             {{list-item-item-schema item=item selecting=(mut item.new)}}
                             {{list-item-add-annotation-menu item=item}}
                             {{list-item-icon icon='remove' action=(action 'removeItem' item) disabled=(lte sample.items.length 1) bubbles=false}}

--- a/portiaui/app/templates/components/jobq-badge.hbs
+++ b/portiaui/app/templates/components/jobq-badge.hbs
@@ -1,0 +1,3 @@
+{{#if isActive}}
+    {{list-item-badge badgeStyle=badgeStyle value=jobCount}}
+{{/if}}

--- a/portiaui/app/templates/components/list-item-badge.hbs
+++ b/portiaui/app/templates/components/list-item-badge.hbs
@@ -1,5 +1,5 @@
 <span class="list-item-badge">
-    <span class="badge" style={{badgeStyle}}>
+    <span class="badge {{badgeClass}}" style={{badgeStyle}}>
         <span class="badge-centered">{{#if hasBlock}}{{yield}}{{else}}{{value}}{{/if}}</span>
     </span>
 </span>

--- a/portiaui/app/templates/components/project-listing.hbs
+++ b/portiaui/app/templates/components/project-listing.hbs
@@ -31,7 +31,7 @@
         {{else if (eq options.section "subtrees")}}
             {{#tree-list-item}}
                 {{#link-to 'projects.project' project}}
-                    {{list-item-icon icon='project'}}
+                    {{list-item-icon icon='project' hasIndent=true}}
                     {{#list-item-text}}
                         {{project.name}}
                     {{/list-item-text}}

--- a/portiaui/app/templates/components/project-structure-listing.hbs
+++ b/portiaui/app/templates/components/project-structure-listing.hbs
@@ -46,7 +46,7 @@
                         {{#if (not currentSpider)}}
                             {{jobq-badge spider=spider}}
                         {{/if}}
-                        {{list-item-icon icon='spider'}}
+                        {{list-item-icon icon='spider' hasIndent=(or (eq spider currentSpider) (not (has-job spider)))}}
                         {{#if currentSpider}}
                             {{#list-item-text}}{{spider.name}}{{/list-item-text}}
                         {{else}}
@@ -112,7 +112,7 @@
             {{#each project.schemas as |schema|}}
                 {{#tree-list-item hide=(and currentSchema (not-eq schema currentSchema)) as |options|}}
                     {{#link-to 'projects.project.schema' schema}}
-                        {{list-item-icon icon='schema'}}
+                        {{list-item-icon icon='schema' hasIndent=true}}
                         {{list-item-editable value=(mut schema.name) editing=(mut schema.new) onChange=(action 'saveSchema' schema)}}
                         {{#animation-container class="icon" setWidth=false setHeight=false}}
                             {{list-item-icon icon='remove' disabled=(not (not schema.items.length)) action=(action 'removeSchema' schema) bubbles=false}}

--- a/portiaui/app/templates/components/project-structure-listing.hbs
+++ b/portiaui/app/templates/components/project-structure-listing.hbs
@@ -19,6 +19,9 @@
                         </p>
                     {{/help-icon}}
                 {{/animation-container}}
+                {{#if showJobs}}
+                    <p class="jobq-message">{{jobMessage}}</p>
+                {{/if}}
             {{/list-item-text}}
             {{#tooltip-container tooltipFor="add-spider-button" text=addSpiderTooltipText tooltipContainer='body'}}
                 {{list-item-icon id="add-spider-button" icon='add' disabled=(not canAddSpider) action=(action 'addSpider')}}
@@ -40,6 +43,9 @@
             {{#each project.spiders as |spider|}}
                 {{#tree-list-item hide=(and currentSpider (not-eq spider currentSpider)) as |options|}}
                     {{#link-to 'projects.project.spider' spider (query-params url=spider.startUrls.firstObject baseurl=null) current-when='projects.project.spider'}}
+                        {{#if (not currentSpider)}}
+                            {{jobq-badge spider=spider}}
+                        {{/if}}
                         {{list-item-icon icon='spider'}}
                         {{#if currentSpider}}
                             {{#list-item-text}}{{spider.name}}{{/list-item-text}}

--- a/portiaui/app/templates/components/project-structure-spider-url.hbs
+++ b/portiaui/app/templates/components/project-structure-spider-url.hbs
@@ -1,6 +1,6 @@
 {{#tree-list-item as |options|}}
     {{#link-to 'projects.project.spider' spider (query-params url=url baseurl=null) active=false}}
-        {{list-item-icon icon='url'}}
+        {{list-item-icon icon='url' hasIndent=true}}
         {{list-item-editable value=(mut viewUrl) editing=(mut urlAdded) spellcheck=false}}
         {{list-item-icon icon='remove' action=(action 'removeStartUrl') bubbles=false}}
     {{/link-to}}

--- a/portiaui/app/templates/components/schema-structure-listing.hbs
+++ b/portiaui/app/templates/components/schema-structure-listing.hbs
@@ -30,7 +30,7 @@
             {{#each schema.fields as |field|}}
                 {{#tree-list-item as |options|}}
                     {{#link-to 'projects.project.schema.field' field}}
-                        {{list-item-icon icon=field.type}}
+                        {{list-item-icon icon=field.type hasIndent=true}}
                         {{list-item-editable value=(mut field.name) editing=(mut field.new) onChange=(action 'saveField' field) validate=(action 'validateFieldName' field)}}
                         {{#list-item-field-type field=field}}
                             Change field type

--- a/portiaui/app/templates/components/spider-structure-listing.hbs
+++ b/portiaui/app/templates/components/spider-structure-listing.hbs
@@ -21,7 +21,12 @@
                 {{/help-icon}}
             {{/list-item-text}}
             {{#tooltip-container tooltipFor="add-start-url-button" text="Start crawling from the current page" tooltipContainer='body'}}
-                {{list-item-icon id="add-start-url-button" icon='add' action=(action 'addStartUrl')}}
+                {{list-item-icon
+                  id="add-start-url-button"
+                  icon='add'
+                  action=(action 'addStartUrl')
+                  hasIndent=true
+                }}
             {{/tooltip-container}}
         {{else if (eq options.section "subtrees")}}
             {{#tree-list-item hide=spider.startUrls.length as |options|}}
@@ -56,7 +61,7 @@
             {{/list-item-text}}
         {{else if (eq options.section "subtrees")}}
             {{#tree-list-item as |options|}}
-                {{list-item-icon icon='link'}}
+                {{list-item-icon icon='link' hasIndent=true}}
                 {{list-item-link-crawling spider=spider}}
                 {{#if (not-eq spider.linksToFollow 'none')}}
                     {{#link-to 'projects.project.spider' bubbles=false}}
@@ -113,7 +118,7 @@
             {{#each spider.samples as |sample|}}
                 {{#tree-list-item hide=(and currentSample (not-eq sample currentSample)) as |options|}}
                     {{#link-to 'projects.project.spider.sample' sample (query-params url=sample.url baseurl=null) current-when='projects.project.spider.sample'}}
-                        {{list-item-icon icon='sample'}}
+                        {{list-item-icon icon='sample' hasIndent=true}}
                         {{list-item-editable value=(mut sample.name) editing=(mut sample.new) onChange=(action 'saveSample' sample)}}
                         {{#animation-container class="icon" setWidth=false setHeight=false}}
                             {{list-item-icon icon='remove' action=(action 'removeSample' sample) bubbles=false}}

--- a/portiaui/tests/unit/services/job-q-test.js
+++ b/portiaui/tests/unit/services/job-q-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:job-q', 'Unit | Service | job q', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let service = this.subject();
+  assert.ok(service);
+});


### PR DESCRIPTION
Integrate jobQ running jobs into Portia UI with an ember service that can be injected throughout the application to query jobQ for running jobs.