### PR TITLE
PORTIA-579: Perform Login bug

### DIFF
--- a/slyd/slyd/resources/models.py
+++ b/slyd/slyd/resources/models.py
@@ -149,6 +149,7 @@ class SpiderSchema(SlydSchema):
     login_url = fields.Str()
     login_user = fields.Str()
     login_password = fields.Str()
+    perform_login = fields.Boolean(default=False)
     template_names = fields.List(fields.Str(), default=[])
     samples = fields.Relationship(
         related_url='/api/projects/{project_id}/spider/{spider_id}/samples',


### PR DESCRIPTION
Add `perform_login` so that a user's `Perform Login` setting for a spider is persisted.