### PR TITLE
PORTIA-598 Normalize start urls

### DIFF
--- a/slybot/slybot/starturls/__init__.py
+++ b/slybot/slybot/starturls/__init__.py
@@ -7,6 +7,7 @@ import six
 from six.moves.urllib_parse import urlparse
 
 from .fragment_generator import FragmentGenerator
+from .generated_url import GeneratedUrl
 from .generator import IdentityGenerator, UrlGenerator
 
 
@@ -29,18 +30,19 @@ class StartUrlCollection(object):
         domains = [start_url.allowed_domains for start_url in self.start_urls]
         return list(set(chain(*domains)))
 
+    def normalize(self):
+        return (start_url.normalized for start_url in self.start_urls)
+
     def _generate_urls(self, start_url):
         generator = self.generators[start_url.generator_type]
         return generator(start_url.generator_value)
 
     def _url_type(self, start_url):
-        if self._is_legacy(start_url):
-            return LegacyUrl(start_url, self.generator_type)
+        if isinstance(start_url, six.string_types):
+            return StringUrl(start_url, self.generator_type)
+        if not (start_url.get('url') and start_url.get('type')):
+            return GeneratedUrl(start_url, self.generator_type)
         return StartUrl(start_url, self.generators)
-
-    def _is_legacy(self, start_url):
-        return (isinstance(start_url, six.string_types) or
-                not (start_url.get('url') and start_url.get('type')))
 
 
 class StartUrl(object):
@@ -51,10 +53,20 @@ class StartUrl(object):
         self.generator_value = self.spec if self._has_fragments else self.spec['url']
 
     @property
+    def key(self):
+        fragments = self.spec.get('fragments', [])
+        fragment_values = [fragment['value'] for fragment in fragments]
+        return self.spec['url'] + ''.join(fragment_values)
+
+    @property
     def allowed_domains(self):
         if self._has_fragments:
             return self._find_fragment_domains()
         return [self.spec['url']]
+
+    @property
+    def normalized(self):
+        return self.spec
 
     def _find_fragment_domains(self):
         generator = self.generators[self.generator_type]
@@ -81,17 +93,11 @@ class StartUrl(object):
         return any(getattr(parsed_url, method) != '' for method in methods)
 
     @property
-    def key(self):
-        fragments = self.spec.get('fragments', [])
-        fragment_values = [fragment['value'] for fragment in fragments]
-        return self.spec['url'] + ''.join(fragment_values)
-
-    @property
     def _has_fragments(self):
         return self.spec.get('fragments')
 
 
-class LegacyUrl(object):
+class StringUrl(object):
     def __init__(self, spec, generator_type):
         self.key = spec
         self.spec = spec
@@ -100,6 +106,8 @@ class LegacyUrl(object):
 
     @property
     def allowed_domains(self):
-        is_generated = self.generator_type == 'generated_urls'
-        url = self.spec['template'] if is_generated else self.spec
-        return [url]
+        return [self.spec]
+
+    @property
+    def normalized(self):
+        return {'url': self.spec, 'type': 'fixed'}

--- a/slybot/slybot/starturls/fragment_generator.py
+++ b/slybot/slybot/starturls/fragment_generator.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from itertools import product
 
 import six
@@ -9,6 +10,10 @@ class FragmentGenerator(object):
 
     def _process_list(self, fragment):
         return fragment.split(' ')
+
+    def _process_date(self, fragment):
+        now = datetime.now()
+        return [now.strftime(fragment)]
 
     def _process_range(self, fragment):
         a, b = map(int, fragment.split('-'))

--- a/slybot/slybot/starturls/generated_url.py
+++ b/slybot/slybot/starturls/generated_url.py
@@ -32,7 +32,7 @@ class GeneratedUrl(object):
     @property
     def normalized_fragments(self):
         fixed, path = self._fixed_fragments, self._path_fragments
-        fragments = zip(fixed, path)
+        fragments = list(zip(fixed, path))
 
         # Missed last fixed fragment when using zip
         if len(fixed) == len(path) + 1:
@@ -64,8 +64,9 @@ class GeneratedUrl(object):
         template_params = self.spec['params_template']
 
         query_params = []
+        param_names = {p['name'] for p in params}
         for query, value in template_params:
-            if query not in [p['name'] for p in params]:
+            if query not in param_names:
                 query_params.append({
                     'name': query,
                     'type': 'default',

--- a/slybot/slybot/starturls/generated_url.py
+++ b/slybot/slybot/starturls/generated_url.py
@@ -1,0 +1,133 @@
+from itertools import chain
+
+
+class GeneratedUrl(object):
+    def __init__(self, spec, generator_type):
+        self.key = spec
+        self.spec = spec
+        self.generator_value = spec
+        self.generator_type = generator_type
+
+    @property
+    def allowed_domains(self):
+        return [self.spec['template']]
+
+    @property
+    def normalized(self):
+        return {
+            'url': self.normalized_url,
+            'type': 'generated',
+            'fragments': self.normalized_fragments,
+        }
+
+    @property
+    def normalized_url(self):
+        paths = [normalize_url_path(path) for path in self.spec['paths']]
+        base_url = self.spec['template'].format(*paths)
+
+        query_params = [normalize_url_query_param(path, is_first=(i == 0))
+                        for i, path in enumerate(self._query_params)]
+        return base_url + ''.join(query_params)
+
+    @property
+    def normalized_fragments(self):
+        fixed, path = self._fixed_fragments, self._path_fragments
+        fragments = zip(fixed, path)
+
+        # Missed last fixed fragment when using zip
+        if len(fixed) == len(path) + 1:
+            fragments.append([fixed[-1]])
+
+        return list(chain.from_iterable(fragments)) + self._query_fragments
+
+    @property
+    def _path_fragments(self):
+        return [normalize_path(path) for path in self.spec['paths']]
+
+    @property
+    def _fixed_fragments(self):
+        return [{'type': 'fixed', 'value': fragment} for fragment in
+                self.spec['template'].split('{}') if fragment]
+
+    @property
+    def _query_fragments(self):
+        if len(self._query_params) == 0:
+            return []
+
+        fragments = [normalize_query_param(query_param, is_first=(i == 0))
+                     for i, query_param in enumerate(self._query_params)]
+        return list(chain(*fragments))
+
+    @property
+    def _query_params(self):
+        params = self.spec['params']
+        template_params = self.spec['params_template']
+
+        query_params = []
+        for query, value in template_params:
+            if query not in [p['name'] for p in params]:
+                query_params.append({
+                    'name': query,
+                    'type': 'default',
+                    'values': [value]
+                })
+        return query_params + params
+
+
+def normalize_path(path):
+    if path['type'] == 'options':
+        return {
+            'type': 'list',
+            'value': ' '.join(path['values']),
+        }
+    if path['type'] == 'default':
+        return {
+            'type': 'fixed',
+            'value': normalize_default(path)
+        }
+    if path['type'] == 'date':
+        return {
+            'type': 'date',
+            'value': normalize_default(path)
+        }
+    if path['type'] == 'range':
+        return {
+            'type': 'range',
+            'value': normalize_range(path)
+            }
+    return None
+
+
+def normalize_url_path(path):
+    if path['type'] == 'default':
+        return normalize_default(path)
+    if path['type'] == 'range':
+        return normalize_range(path)
+    return '[...]'
+
+
+def normalize_url_query_param(x, is_first=False):
+    prefix = query_params_prefix(is_first).format(x['name'])
+    return prefix + normalize_url_path(x)
+
+
+def normalize_query_param(x, is_first=False):
+    first_fragment = {
+        'type': 'fixed',
+        'value': query_params_prefix(is_first).format(x['name'])
+    }
+    return [first_fragment, normalize_path(x)]
+
+
+def normalize_default(x):
+    return str(x['values'][0])
+
+
+def normalize_range(x):
+    a, b = x['values'][0:2]
+    b_inclusive = str(int(b) - 1)
+    return '{}-{}'.format(a, b_inclusive)
+
+
+def query_params_prefix(is_first):
+    return '?{}=' if is_first else '&{}='

--- a/slybot/slybot/tests/test_starturls.py
+++ b/slybot/slybot/tests/test_starturls.py
@@ -176,3 +176,284 @@ class StartUrlCollectionTest(TestCase):
         ]
         collection_domains = StartUrlCollection(start_urls, self.generators).allowed_domains
         self.assertEqual(collection_domains, [])
+
+    def test_normalize_string_url(self):
+        legacy = ['https://github.com/scrapinghub']
+        normalized = [{
+            'url': 'https://github.com/scrapinghub',
+            'type': 'fixed',
+        }]
+        collection = StartUrlCollection(legacy, self.generators)
+
+        self.assertEqual(legacy[0], normalized[0]['url'])
+        self.assertEqual(list(collection.normalize()), normalized)
+
+    def test_normalize_start_url(self):
+        start_urls = [{
+            'url': 'https://github.com/scrapinghub',
+            'type': 'fixed',
+        }]
+        collection = StartUrlCollection(start_urls, self.generators)
+
+        self.assertEqual(list(collection.normalize()), start_urls)
+
+    def test_normalize_generated_options(self):
+        legacy = [{
+            "template": "https://github.com/{}",
+            "paths": [{
+                "type": "options",
+                "values": ["scrapinghub", "scrapy", "scrapy-plugins"],
+            }],
+            "params": [],
+            "params_template": {}
+        }]
+        normalized = [{
+            'url': 'https://github.com/[...]',
+            'type': 'generated',
+            'fragments': [
+                {'type': 'fixed', 'value': 'https://github.com/'},
+                {
+                    'type': 'list',
+                    'value': 'scrapinghub scrapy scrapy-plugins',
+                },
+            ]
+        }]
+        collection = StartUrlCollection(legacy, self.generators)
+
+        self.assertEqual(generator_set(UrlGenerator, legacy[0]),
+                         generator_set(FragmentGenerator, normalized[0]))
+        self.assertEqual(list(collection.normalize()), normalized)
+
+    def test_normalize_generated_default(self):
+        legacy = [{
+            "template": "https://github.com/{}/fixed",
+            "paths": [{
+                "type": "default",
+                "values": ["scrapinghub", "scrapy", "scrapy-plugins"],
+            }],
+            "params": [],
+            "params_template": {}
+        }]
+        normalized = [{
+            'url': 'https://github.com/scrapinghub/fixed',
+            'type': 'generated',
+            'fragments': [
+                {'type': 'fixed', 'value': 'https://github.com/'},
+                {
+                    'type': 'fixed',
+                    'value': 'scrapinghub',
+                },
+                {'type': 'fixed', 'value': '/fixed'},
+            ]
+        }]
+        collection = StartUrlCollection(legacy, self.generators)
+
+        self.assertEqual(generator_set(UrlGenerator, legacy[0]),
+                         generator_set(FragmentGenerator, normalized[0]))
+        self.assertEqual(list(collection.normalize()), normalized)
+
+    def test_normalize_generated_dates(self):
+        legacy = [{
+            "template": "http://www.commitstrip.com/{}/{}/{}",
+            "paths": [{
+                "type": "default",
+                "values": ["en"]
+            }, {
+                "type": "date",
+                "values": ["%Y"],
+            }, {
+                "type": "date",
+                "values": ["%m"]
+            }],
+            "params": [],
+            "params_template": {}
+        }]
+        normalized = [{
+            'url': 'http://www.commitstrip.com/en/[...]/[...]',
+            'type': 'generated',
+            'fragments': [
+                {'type': 'fixed', 'value': 'http://www.commitstrip.com/'},
+                {'type': 'fixed', 'value': 'en'},
+                {'type': 'fixed', 'value': '/'},
+                {'type': 'date', 'value': '%Y'},
+                {'type': 'fixed', 'value': '/'},
+                {'type': 'date', 'value': '%m'},
+            ]
+        }]
+        collection = StartUrlCollection(legacy, self.generators)
+
+        self.assertEqual(generator_set(UrlGenerator, legacy[0]),
+                         generator_set(FragmentGenerator, normalized[0]))
+        self.assertEqual(list(collection.normalize()), normalized)
+
+    def test_normalized_generated_range(self):
+        legacy = [{
+            "template": "https://www.donedeal.ie/{}/{}/{}",
+            "paths": [{
+                "type": "default",
+                "values": ["cars-for-sale"]
+            }, {
+                "type": "options",
+                "values": ["i"],
+            }, {
+                "type": "range",
+                "values": [10, 20]
+            }],
+            "params": [],
+            "params_template": {}
+        }]
+        normalized = [{
+            'url': 'https://www.donedeal.ie/cars-for-sale/[...]/10-19',
+            'type': 'generated',
+            'fragments': [
+                {'type': 'fixed', 'value': 'https://www.donedeal.ie/'},
+                {'type': 'fixed', 'value': 'cars-for-sale'},
+                {'type': 'fixed', 'value': '/'},
+                {'type': 'list', 'value': 'i'},
+                {'type': 'fixed', 'value': '/'},
+                {'type': 'range', 'value': '10-19'},
+            ]
+        }]
+        collection = StartUrlCollection(legacy, self.generators)
+
+        self.assertEqual(generator_set(UrlGenerator, legacy[0]),
+                         generator_set(FragmentGenerator, normalized[0]))
+        self.assertEqual(list(collection.normalize()), normalized)
+
+    def test_normalized_generated_params_range(self):
+        legacy = [{
+            "template": "http://www.smbc-comics.com/{}",
+            "paths": [{
+                "type": "default",
+                "values": ["index.php"]
+            }],
+            "params": [{
+                "name": "p",
+                "type": "range",
+                "values": [20, 31]
+            }, {
+                "name": "q",
+                "type": "options",
+                "values": ['comic']
+            }],
+            "params_template": {}
+        }]
+        normalized = [{
+            'url': 'http://www.smbc-comics.com/index.php?p=20-30&q=[...]',
+            'type': 'generated',
+            'fragments': [
+                {'type': 'fixed', 'value': 'http://www.smbc-comics.com/'},
+                {'type': 'fixed', 'value': 'index.php'},
+                {'type': 'fixed', 'value': '?p='},
+                {'type': 'range', 'value': '20-30'},
+                {'type': 'fixed', 'value': '&q='},
+                {'type': 'list', 'value': 'comic'},
+            ]
+        }]
+        collection = StartUrlCollection(legacy, self.generators)
+
+        self.assertEqual(generator_set(UrlGenerator, legacy[0]),
+                         generator_set(FragmentGenerator, normalized[0]))
+        self.assertEqual(list(collection.normalize()), normalized)
+
+    def test_normalized_generated_template_params(self):
+        legacy = [{
+            "template": "https://encrypted.google.com/search",
+            "paths": [],
+            "params": [{
+                "name": "q",
+                "type": "options",
+                "values": ["nosetests", "tox"]
+            }, {
+                "name": "location",
+                "type": "options",
+                "values": ["dublin", "cork"]
+            }],
+            "params_template": [
+                ("hl", "en"),
+                ("q", "python unittest")
+            ]
+        }]
+        normalized = [{
+            'url': 'https://encrypted.google.com/search?hl=en&q=[...]&location=[...]',
+            'type': 'generated',
+            'fragments': [
+                {'type': 'fixed', 'value': 'https://encrypted.google.com/search'},
+                {'type': 'fixed', 'value': '?hl='},
+                {'type': 'fixed', 'value': 'en'},
+                {'type': 'fixed', 'value': '&q='},
+                {'type': 'list', 'value': 'nosetests tox'},
+                {'type': 'fixed', 'value': '&location='},
+                {'type': 'list', 'value': 'dublin cork'},
+            ]
+        }]
+        collection = StartUrlCollection(legacy, self.generators)
+
+        self.assertEqual(generator_set(UrlGenerator, legacy[0]),
+                         generator_set(FragmentGenerator, normalized[0]))
+        self.assertEqual(list(collection.normalize()), normalized)
+
+    def test_normalized_mixed(self):
+        legacy = [
+            {
+                "template": "http://www.smbc-comics.com/{}",
+                "paths": [{
+                    "type": "default",
+                    "values": ["index.php"]
+                }],
+                "params": [{
+                    "name": "p",
+                    "type": "range",
+                    "values": [20, 31]
+                }, {
+                    "name": "q",
+                    "type": "options",
+                    "values": ['comic']
+                }],
+                "params_template": {}
+            },
+            'http://github.com/scrapinghub.com',
+            {
+                'url': 'https://github.com/[...]',
+                'type': 'generated',
+                'fragments': [
+                    {'type': 'fixed', 'value': 'https://github.com/'},
+                    {
+                        'type': 'list',
+                        'value': 'scrapinghub scrapy scrapy-plugins',
+                    },
+                ]
+            }
+        ]
+        normalized = [
+            {
+                'url': 'http://www.smbc-comics.com/index.php?p=20-30&q=[...]',
+                'type': 'generated',
+                'fragments': [
+                    {'type': 'fixed', 'value': 'http://www.smbc-comics.com/'},
+                    {'type': 'fixed', 'value': 'index.php'},
+                    {'type': 'fixed', 'value': '?p='},
+                    {'type': 'range', 'value': '20-30'},
+                    {'type': 'fixed', 'value': '&q='},
+                    {'type': 'list', 'value': 'comic'},
+                ]
+            },
+            {'url': 'http://github.com/scrapinghub.com', 'type': 'fixed'},
+            {
+                'url': 'https://github.com/[...]',
+                'type': 'generated',
+                'fragments': [
+                    {'type': 'fixed', 'value': 'https://github.com/'},
+                    {
+                        'type': 'list',
+                        'value': 'scrapinghub scrapy scrapy-plugins',
+                    },
+                ]
+            },
+        ]
+        collection = StartUrlCollection(legacy, self.generators)
+
+        self.assertEqual(list(collection.normalize()), normalized)
+
+def generator_set(generator, start_urls):
+    return set(list(generator()(start_urls)))


### PR DESCRIPTION
The `StartUrlCollection` allows three types of start urls:

* `StringUrl`: legacy start url which is just a string
* `GeneratedUrl`: legacy start url which was used for kimono urls
* `StartUrl`: new start urls based on fragments

I exposed `normalize` in `StartUrlCollection` which normalizes all types of urls to use the new fragments structure. This allows us to normalize start urls in the `pre_load` hook in the ORM to start gradually converting start urls.

This normalization in turn simplifies the validations we perform on the start urls field for spiders using the ORM validators.