### PR TITLE
Indentation within Portia's left panel

### DIFF
--- a/portiaui/app/components/indentation-spacer.js
+++ b/portiaui/app/components/indentation-spacer.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  classNames: ['indentation-spacer'],
+  classNameBindings: ['isSmall'],
+  isSmall: false
+});

--- a/portiaui/app/styles/app.scss
+++ b/portiaui/app/styles/app.scss
@@ -99,3 +99,4 @@
 @import "components/start-url-options";
 @import "components/fragment-options";
 @import "components/project-structure-spider-generation-url";
+@import "components/indentation-spacer";

--- a/portiaui/app/styles/components/indentation-spacer.scss
+++ b/portiaui/app/styles/components/indentation-spacer.scss
@@ -1,0 +1,6 @@
+.indentation-spacer {
+    width: 20px;
+    &.is-small {
+        width: 10px;
+    }
+}

--- a/portiaui/app/styles/components/list-item-badge.scss
+++ b/portiaui/app/styles/components/list-item-badge.scss
@@ -1,6 +1,6 @@
 .list-item-badge {
     display: inline-block;
-    flex: 0 0 26px;
+    flex: 0 0 20px;
     text-align: center;
 
     .badge {

--- a/portiaui/app/styles/components/list-item-editable.scss
+++ b/portiaui/app/styles/components/list-item-editable.scss
@@ -6,13 +6,6 @@
     flex: 1 1 auto;
     min-width: 0;
 
-    .list-item-icon + &,
-    .list-item-badge + &,
-    .list-item-selectable + &,
-    & + & {
-        margin-left: $space-width;
-    }
-
     > span {
         flex: 0 1 auto;
         white-space: nowrap;

--- a/portiaui/app/styles/components/list-item-selectable.scss
+++ b/portiaui/app/styles/components/list-item-selectable.scss
@@ -6,13 +6,6 @@
     flex: 0 1 auto;
 
     .list-item-icon + &,
-    .list-item-badge + &,
-    .list-item-editable + &,
-    & + & {
-        margin-left: $space-width;
-    }
-
-    .list-item-icon + &,
     .list-item-badge + & {
         flex-grow: 1;
     }

--- a/portiaui/app/templates/components/data-structure-annotations.hbs
+++ b/portiaui/app/templates/components/data-structure-annotations.hbs
@@ -6,8 +6,12 @@
             {{#if (eq annotation.constructor.modelName "annotation")}}
                 {{#tree-list-item onMouseEnter=(action 'enterAnnotation' annotation) onMouseLeave=(action 'leaveAnnotation' item) as |options|}}
                     {{#link-to 'projects.project.spider.sample.data.annotation' annotation}}
+                        {{indentation-spacer isSmall=true}}
+                        {{list-item-badge
+                          value=(or annotation.elements.length 0)
+                          color=(array-get annotationColors annotation.orderedIndex)
+                        }}
                         {{list-item-icon icon=annotation.type}}
-                        {{list-item-badge value=(or annotation.elements.length 0) color=(array-get annotationColors annotation.orderedIndex)}}
                         {{list-item-annotation-field annotation=annotation selecting=(mut annotation.new)}}
                         {{#list-item-field-type field=annotation.field}}
                             Change type of selected field

--- a/portiaui/app/templates/components/data-structure-listing.hbs
+++ b/portiaui/app/templates/components/data-structure-listing.hbs
@@ -10,8 +10,8 @@
                 {{#unless item.parent}}
                     {{#data-structure-annotations sample=sample item=item annotationColors=annotationColors}}
                         {{#link-to 'projects.project.spider.sample.data.item' item}}
-                            {{list-item-icon icon='schema'}}
                             {{list-item-badge value=(or item.elements.length 0)}}
+                            {{list-item-icon icon='schema'}}
                             {{list-item-item-schema item=item selecting=(mut item.new)}}
                             {{list-item-add-annotation-menu item=item}}
                             {{list-item-icon icon='remove' action=(action 'removeItem' item) disabled=(lte sample.items.length 1) bubbles=false}}

--- a/portiaui/app/templates/components/project-listing.hbs
+++ b/portiaui/app/templates/components/project-listing.hbs
@@ -31,6 +31,7 @@
         {{else if (eq options.section "subtrees")}}
             {{#tree-list-item}}
                 {{#link-to 'projects.project' project}}
+                    {{indentation-spacer}}
                     {{list-item-icon icon='project'}}
                     {{#list-item-text}}
                         {{project.name}}

--- a/portiaui/app/templates/components/project-structure-listing.hbs
+++ b/portiaui/app/templates/components/project-structure-listing.hbs
@@ -19,6 +19,7 @@
                         </p>
                     {{/help-icon}}
                 {{/animation-container}}
+                {{spider-message currentSpider=currentSpider}}
             {{/list-item-text}}
             {{#tooltip-container tooltipFor="add-spider-button" text=addSpiderTooltipText tooltipContainer='body'}}
                 {{list-item-icon id="add-spider-button" icon='add' disabled=(not canAddSpider) action=(action 'addSpider')}}
@@ -40,7 +41,9 @@
             {{#each project.spiders as |spider|}}
                 {{#tree-list-item hide=(and currentSpider (not-eq spider currentSpider)) as |options|}}
                     {{#link-to 'projects.project.spider' spider (query-params url=(or spider.firstUrl null) baseurl=null) current-when='projects.project.spider'}}
+                        {{spider-indentation spider=spider currentSpider=currentSpider}}
                         {{list-item-icon icon='spider'}}
+
                         {{#if currentSpider}}
                             {{#list-item-text}}{{spider.name}}{{/list-item-text}}
                         {{else}}
@@ -106,6 +109,7 @@
             {{#each project.schemas as |schema|}}
                 {{#tree-list-item hide=(and currentSchema (not-eq schema currentSchema)) as |options|}}
                     {{#link-to 'projects.project.schema' schema}}
+                        {{indentation-spacer}}
                         {{list-item-icon icon='schema'}}
                         {{list-item-editable value=(mut schema.name) editing=(mut schema.new) onChange=(action 'saveSchema' schema)}}
                         {{#animation-container class="icon" setWidth=false setHeight=false}}

--- a/portiaui/app/templates/components/project-structure-spider-generation-url.hbs
+++ b/portiaui/app/templates/components/project-structure-spider-generation-url.hbs
@@ -1,5 +1,6 @@
 {{#tree-list-item as |options|}}
     {{#link-to 'projects.project.spider.start-url.options' index bubbles=false}}
+        {{indentation-spacer}}
         {{list-item-icon icon='url-generated'}}
         {{#list-item-text class="generated-url"}}{{url}}{{/list-item-text}}
         {{#link-to 'projects.project.spider' bubbles=false}}

--- a/portiaui/app/templates/components/project-structure-spider-url.hbs
+++ b/portiaui/app/templates/components/project-structure-spider-url.hbs
@@ -1,5 +1,6 @@
 {{#tree-list-item as |options|}}
     {{#link-to 'projects.project.spider' spider (query-params url=url baseurl=null) active=false}}
+        {{indentation-spacer}}
         {{list-item-icon icon='url'}}
         {{list-item-editable value=(mut viewUrl) editing=(mut urlAdded) spellcheck=false}}
         {{list-item-icon icon='remove' action=(action removeStartUrl) bubbles=false}}

--- a/portiaui/app/templates/components/schema-structure-listing.hbs
+++ b/portiaui/app/templates/components/schema-structure-listing.hbs
@@ -30,6 +30,7 @@
             {{#each schema.fields as |field|}}
                 {{#tree-list-item as |options|}}
                     {{#link-to 'projects.project.schema.field' field}}
+                        {{indentation-spacer}}
                         {{list-item-icon icon=field.type}}
                         {{list-item-editable value=(mut field.name) editing=(mut field.new) onChange=(action 'saveField' field) validate=(action 'validateFieldName' field)}}
                         {{#list-item-field-type field=field}}

--- a/portiaui/app/templates/components/spider-indentation.hbs
+++ b/portiaui/app/templates/components/spider-indentation.hbs
@@ -1,0 +1,1 @@
+{{indentation-spacer}}

--- a/portiaui/app/templates/components/spider-structure-listing.hbs
+++ b/portiaui/app/templates/components/spider-structure-listing.hbs
@@ -21,7 +21,7 @@
                 {{/help-icon}}
             {{/list-item-text}}
             {{#tooltip-container tooltipFor="add-start-url-button" text="Start crawling from the current page" tooltipContainer='body'}}
-
+                {{indentation-spacer}}
                 {{#list-item-icon-menu icon='add-dropdown' as |options|}}
                     {{#options.item value="Add fixed URL" action=(chain-actions (action 'addStartUrl') options.closeMenu) as |value|}}
                         {{list-item-icon class="icon" icon="url"}}{{value}}
@@ -30,7 +30,6 @@
                         {{list-item-icon class="icon" icon="url-generated"}}{{value}}
                     {{/options.item}}
                 {{/list-item-icon-menu}}
-
             {{/tooltip-container}}
         {{else if (eq options.section "subtrees")}}
             {{#tree-list-item hide=spider.startUrls.length as |options|}}
@@ -83,6 +82,7 @@
             {{/list-item-text}}
         {{else if (eq options.section "subtrees")}}
             {{#tree-list-item as |options|}}
+                {{indentation-spacer}}
                 {{list-item-icon icon='link'}}
                 {{list-item-link-crawling spider=spider}}
                 {{#if (not-eq spider.linksToFollow 'none')}}
@@ -140,6 +140,7 @@
             {{#each spider.samples as |sample|}}
                 {{#tree-list-item hide=(and currentSample (not-eq sample currentSample)) as |options|}}
                     {{#link-to 'projects.project.spider.sample' sample (query-params url=sample.url baseurl=null) current-when='projects.project.spider.sample'}}
+                        {{indentation-spacer}}
                         {{list-item-icon icon='sample'}}
                         {{list-item-editable value=(mut sample.name) editing=(mut sample.new) onChange=(action 'saveSample' sample)}}
                         {{#animation-container class="icon" setWidth=false setHeight=false}}

--- a/portiaui/app/templates/components/spider-structure-listing.hbs
+++ b/portiaui/app/templates/components/spider-structure-listing.hbs
@@ -21,7 +21,6 @@
                 {{/help-icon}}
             {{/list-item-text}}
             {{#tooltip-container tooltipFor="add-start-url-button" text="Start crawling from the current page" tooltipContainer='body'}}
-                {{indentation-spacer}}
                 {{#list-item-icon-menu icon='add-dropdown' as |options|}}
                     {{#options.item value="Add fixed URL" action=(chain-actions (action 'addStartUrl') options.closeMenu) as |value|}}
                         {{list-item-icon class="icon" icon="url"}}{{value}}


### PR DESCRIPTION
Indentation on Portia's left panel gives visual clarity to the nesting of list items in the left panel and is quite useful for badges showing counts. Concretely, this nesting allows badges showing when a spider is running.