### PR TITLE
  Portia django rename spider

### DIFF
--- a/portia_server/portia_api/resources/models.py
+++ b/portia_server/portia_api/resources/models.py
@@ -135,7 +135,7 @@ class FieldSchema(SlydSchema):
 
 class SpiderSchema(SlydSchema):
     id = fields.Str(dump_only=True, load_from='name')
-    name = fields.Str(load_from='id')
+    name = fields.Str()
     start_urls = fields.List(fields.Str(), default=[])
     links_to_follow = fields.Str(default='patterns')
     follow_patterns = fields.List(fields.Str(), default=[])

--- a/portia_server/portia_api/resources/spiders.py
+++ b/portia_server/portia_api/resources/spiders.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from django.http.response import Http404
 
 import requests
 
@@ -23,6 +24,19 @@ class SpiderRoute(ProjectDownloadMixin, BaseProjectModelRoute):
 
     def get_collection(self):
         return self.project.spiders
+
+    @detail_route(methods=['post'])
+    def rename(self, *args, **kwargs):
+        try:
+            spider = self.get_instance()
+            spider.id = self.data['name']
+            spider.save()
+            self.storage.commit()
+        except (TypeError, IndexError, KeyError):
+            raise Http404
+
+        data = self.get_serializer(spider).data
+        return Response(data, status=HTTP_200_OK)
 
     @detail_route(methods=['post'])
     def schedule(self):

--- a/portiaui/app/models/spider.js
+++ b/portiaui/app/models/spider.js
@@ -3,8 +3,17 @@ import DS from 'ember-data';
 import BaseModel from './base';
 
 export default BaseModel.extend({
-    name: Ember.computed.alias('id'),
-    // name: DS.attr('string'),
+    name: DS.attr('string'),
+    nameAlias: Ember.computed('id', 'name', {
+        get() {
+            return this.get('name') || this.get('id');
+        },
+        set(key, value) {
+            this.set('name', value);
+            return value;
+        }
+    }),
+
     startUrls: DS.attr('startUrl', {
         defaultValue() {
             return [];

--- a/portiaui/app/services/dispatcher.js
+++ b/portiaui/app/services/dispatcher.js
@@ -41,16 +41,8 @@ export function computedCanAddStartUrl(spiderPropertyName) {
     });
 }
 
-function jsonPayload(data) {
-    return {
-        dataType: 'json',
-        contentType: 'application/json; charset=UTF-8',
-        data: JSON.stringify(data)
-    };
-}
-
 export default Ember.Service.extend({
-    ajax: Ember.inject.service(),
+    api: Ember.inject.service(),
     browser: Ember.inject.service(),
     routing: Ember.inject.service('-routing'),
     selectorMatcher: Ember.inject.service(),
@@ -353,11 +345,11 @@ export default Ember.Service.extend({
     },
 
     changeSpiderName(spider) {
-        const url = `api/projects/${spider.get('project.id')}/` +
-                    `spiders/${spider.get('id')}/rename`;
-        const data = jsonPayload({name: spider.get('name')});
-
-        return this.get('ajax').post(url, data);
+        const data = { name: spider.get('name') };
+        return this.get('api').post('rename', {
+            model: spider,
+            jsonData: data
+        });
     },
 
     changeAnnotationSource(annotation, attribute) {

--- a/portiaui/app/templates/components/project-structure-listing.hbs
+++ b/portiaui/app/templates/components/project-structure-listing.hbs
@@ -45,9 +45,9 @@
                         {{list-item-icon icon='spider'}}
 
                         {{#if currentSpider}}
-                            {{#list-item-text}}{{spider.name}}{{/list-item-text}}
+                            {{#list-item-text}}{{spider.nameAlias}}{{/list-item-text}}
                         {{else}}
-                            {{list-item-editable value=(mut spider.name) onChange=(action 'saveSpiderName' spider) validate=(action 'validateSpiderName')}}
+                            {{list-item-editable value=(mut spider.nameAlias) onChange=(action 'saveSpiderName' spider) validate=(action 'validateSpiderName')}}
                         {{/if}}
                         {{#animation-container class="icon" setWidth=false setHeight=false}}
                             {{list-item-icon icon='remove' action=(action 'removeSpider' spider) bubbles=false}}

--- a/portiaui/app/utils/selectors.js
+++ b/portiaui/app/utils/selectors.js
@@ -954,6 +954,5 @@ export default {
     smartSelector,
     cssToXpath,
     findContainer,
-    findRepeatedContainers,
-    updateStructureSelectors
+    findRepeatedContainers
 };


### PR DESCRIPTION
Allow user to rename a spider using a custom endpoint for django and bypassing Ember's constraint of not changing ids in the UI.