### PR TITLE
Add FeedGenerator

### DIFF
--- a/slybot/slybot/spider.py
+++ b/slybot/slybot/spider.py
@@ -17,7 +17,8 @@ from six.moves.urllib_parse import urlparse
 from slybot.generic_form import GenericForm
 from slybot.linkextractor import create_linkextractor_from_specs
 from slybot.starturls import (
-    FragmentGenerator, IdentityGenerator, StartUrlCollection, UrlGenerator
+    FragmentGenerator, FeedGenerator, IdentityGenerator, StartUrlCollection,
+    UrlGenerator
 )
 from slybot.utils import (
     include_exclude_filter, IndexedDict, iter_unique_scheme_hostname,
@@ -38,8 +39,8 @@ class IblSpider(SitemapSpider):
             'generated_urls': UrlGenerator(settings, kw),
 
             'url': IdentityGenerator(),
+            'feed': FeedGenerator(self.parse),
             'generated': FragmentGenerator(),
-            # 'feed_urls': FeedUrls(self, settings, kw)
         }
         self.generic_form = GenericForm(**kw)
         super(IblSpider, self).__init__(name, **kw)
@@ -67,7 +68,6 @@ class IblSpider(SitemapSpider):
         return StartUrlCollection(
             arg_to_iter(spec[url_type]),
             self.start_url_generators,
-            url_type
         )
 
     def _create_start_requests(self, spec):

--- a/slybot/slybot/starturls/feed_generator.py
+++ b/slybot/slybot/starturls/feed_generator.py
@@ -1,0 +1,15 @@
+from scrapy import Request
+
+
+class FeedGenerator(object):
+    def __init__(self, callback):
+        self.callback = callback
+
+    def __call__(self, url):
+        return Request(url, callback=self.parse_urls)
+
+    def parse_urls(self, response):
+        newline_urls = response.text.split('\n')
+        urls = [url.replace('\r', '') for url in newline_urls if url]
+        for url in urls:
+            yield Request(url, callback=self.callback)

--- a/slybot/slybot/starturls/generated_url.py
+++ b/slybot/slybot/starturls/generated_url.py
@@ -2,11 +2,11 @@ from itertools import chain
 
 
 class GeneratedUrl(object):
-    def __init__(self, spec, generator_type):
+    def __init__(self, spec):
         self.key = spec
         self.spec = spec
         self.generator_value = spec
-        self.generator_type = generator_type
+        self.generator_type = 'generated_urls'
 
     @property
     def allowed_domains(self):

--- a/slybot/slybot/tests/test_starturls.py
+++ b/slybot/slybot/tests/test_starturls.py
@@ -33,7 +33,7 @@ class StartUrlCollectionTest(TestCase):
             'https://github.com/2',
         ]
 
-        generated = StartUrlCollection(start_urls, self.generators, 'start_urls')
+        generated = StartUrlCollection(start_urls, self.generators)
         self.assertEqual(list(generated), generated_start_urls)
 
     def test_generated_type(self):
@@ -53,7 +53,7 @@ class StartUrlCollectionTest(TestCase):
                 "params_template": {}
             },
         ]
-        generated = StartUrlCollection(start_urls, self.generators, 'generated_urls')
+        generated = StartUrlCollection(start_urls, self.generators)
 
         self.assertEqual(list(generated), generated_start_urls)
 


### PR DESCRIPTION
Handle `generator_type` with duck typing instead of passing it as a parameter. Add the FeedGenerator to handle files with newline separated urls in slybot.