### PR TITLE
Better handle errors thrown in API

### DIFF
--- a/portia_server/portia_api/resources/projects.py
+++ b/portia_server/portia_api/resources/projects.py
@@ -47,8 +47,11 @@ class BaseProjectRoute(JsonApiRoute):
     @cached_property
     def project(self):
         project_id = self.kwargs.get('project_id')
-        name = self.projects[project_id]
-        return Project(self.storage, id=project_id, name=name)
+        try:
+            name = self.projects[project_id]
+            return Project(self.storage, id=project_id, name=name)
+        except KeyError:
+            raise JsonApiNotFoundError()
 
 
 class BaseProjectModelRoute(BaseProjectRoute, JsonApiModelRoute):

--- a/portia_server/portia_api/resources/spiders.py
+++ b/portia_server/portia_api/resources/spiders.py
@@ -30,6 +30,11 @@ class SpiderRoute(ProjectDownloadMixin, BaseProjectModelRoute):
     def extract(self, *args, **kwargs):
         try:
             instance = self.get_instance()
+        except TypeError:
+            raise JsonApiGeneralException(
+                'No spider found with the name "%s"' % kwargs.get('spider_id'),
+                404)
+        try:
             spider = load_spider(self.storage, instance)
         except (ValueError, KeyError, IndexError):
             import traceback

--- a/portia_server/portia_server/settings.py
+++ b/portia_server/portia_server/settings.py
@@ -112,6 +112,7 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'portia_server.backends.LocalAuthentication',
     ),
+    'EXCEPTION_HANDLER': 'portia_api.jsonapi.exceptions.jsonapi_exception_handler',
     'URL_FORMAT_OVERRIDE': None
 }
 


### PR DESCRIPTION
Use a custom exception handler to format jsonapi errors correctly
Format json errors in a similar fashion to jsonapi errors
Add unique ids to errors to avoid them being displayed more than once in the UI
Show user the error message returned by the api if the status code is < 500