### PR TITLE
PORTIA-695: Find Portia project through url

### DIFF
--- a/portiaui/app/adapters/project.js
+++ b/portiaui/app/adapters/project.js
@@ -2,5 +2,6 @@ import ApplicationAdapter from './application';
 
 export default ApplicationAdapter.extend({
     urlTemplate: '{+host}/api/projects{/id}',
+    findRecordUrlTemplate: '{+host}/api/projects{/id}',
     createRecordUrlTemplate: '{+host}/api/projects'
 });

--- a/portiaui/app/routes/projects/project.js
+++ b/portiaui/app/routes/projects/project.js
@@ -3,9 +3,11 @@ import Ember from 'ember';
 export default Ember.Route.extend({
     browser: Ember.inject.service(),
     capabilities: Ember.inject.service(),
+    notificationManager: Ember.inject.service(),
 
     model(params) {
-        return this.store.peekRecord('project', params.project_id);
+        this.set('projectId', params.project_id);
+        return this.store.findRecord('project', params.project_id);
     },
 
     afterModel(model) {
@@ -52,8 +54,15 @@ export default Ember.Route.extend({
         });
     },
 
+    projectNotFound() {
+        const id = this.get('projectId');
+        const errorMsg = `Project with id '${id}' not found.`;
+        this.get('notificationManager').showErrorNotification(errorMsg);
+    },
+
     actions: {
         error: function() {
+            this.projectNotFound();
             this.transitionTo('projects');
         },
 


### PR DESCRIPTION
Given a user navigates to `/projects/project_id`, Ember will try to find the record and display a `Not Found` error if the project does not exist.