### PR TITLE
Handle required fields from schemas in item processor

### DIFF
--- a/slybot/slybot/plugins/scrapely_annotations/annotations.py
+++ b/slybot/slybot/plugins/scrapely_annotations/annotations.py
@@ -7,7 +7,6 @@ import re
 from collections import OrderedDict
 
 from scrapy.http import Request
-from scrapy.selector import Selector
 from scrapy.utils.misc import arg_to_iter
 
 from scrapely.extraction import InstanceBasedLearningExtractor
@@ -143,16 +142,10 @@ class Annotations(object):
     def _do_extract_items_from(self, htmlpage, extractor, response=None):
         # Try to predict template to use
         template_cluster, pref_template_id = self._cluster_page(htmlpage)
-        extracted_data, template = extractor.extract(htmlpage, pref_template_id)
-        extracted = []
-        sel = Selector(text=htmlpage.body)
-        for item in arg_to_iter(extracted_data):
-            try:
-                extracted.append(item.process(sel))
-            except AttributeError:
-                extracted.append(item)
+        extracted, template = extractor.extract(htmlpage, pref_template_id)
+        extracted = extracted or []
         link_regions = []
-        for ddict in extracted or []:
+        for ddict in extracted:
             link_regions.extend(arg_to_iter(ddict.pop("_links", [])))
         descriptor = None
         unprocessed = False

--- a/slybot/slybot/plugins/scrapely_annotations/extraction/container_extractors.py
+++ b/slybot/slybot/plugins/scrapely_annotations/extraction/container_extractors.py
@@ -213,8 +213,7 @@ class BaseContainerExtractor(object):
                                   htmlpage)
 
         # Check if item is valid
-        dumped = processor.dump()
-        if dumped:
+        if len(processor):
             return processor
         else:
             return {}
@@ -321,9 +320,10 @@ class ContainerExtractor(BaseContainerExtractor, BasicTypeExtractor):
         return items
 
     def _merge_items(self, items):
+        items = sorted((i for i in items if len(i)),
+                       key=lambda x: x.name or '')
         if not items:
             return []
-        items = sorted(items, key=lambda x: x.name or '')
         item = items[0]
         for other_item in items[1:]:
             item.merge(other_item)

--- a/slybot/slybot/tests/data/SampleProject/items.json
+++ b/slybot/slybot/tests/data/SampleProject/items.json
@@ -267,9 +267,9 @@
             "aee3-4653-945f": {
                 "id": "aee3-4653-945f",
                 "name": "image",
-                "required": false,
+                "required": true,
                 "type": "image",
-                "vary": false
+                "vary": true
             },
             "85cb-43ca-928b": {
                 "id": "85cb-43ca-928b",
@@ -316,7 +316,7 @@
             "1312-419b-afcd": {
                 "id": "1312-419b-afcd",
                 "name": "stock",
-                "required": false,
+                "required": true,
                 "type": "number",
                 "vary": false
             },

--- a/slybot/slybot/tests/data/SampleProject/spiders/books.toscrape.com/3617-44af-a2f0.json
+++ b/slybot/slybot/tests/data/SampleProject/spiders/books.toscrape.com/3617-44af-a2f0.json
@@ -42,7 +42,7 @@
               "attribute": "src",
               "extractors": {},
               "field": "aee3-4653-945f",
-              "required": true
+              "required": false
             }
           },
           "id": "9fec-4790-86d9",
@@ -97,7 +97,7 @@
               "attribute": "content",
               "extractors": {},
               "field": "71ed-4634-b777",
-              "required": false
+              "required": true
             }
           },
           "id": "5c6c-49b4-b4c2",

--- a/slybot/slybot/tests/test_extractors.py
+++ b/slybot/slybot/tests/test_extractors.py
@@ -134,7 +134,7 @@ class ExtractorTest(TestCase):
 
         ibl_extractor = SlybotIBLExtractor([
             (self.template, {'#default': descriptor}, '0.12.0')])
-        self.assertEqual(ibl_extractor.extract(self.target)[0][0].dump()['gender'], [u'<td >Male</td>'])
+        self.assertEqual(ibl_extractor.extract(self.target)[0][0]['gender'], [u'<td >Male</td>'])
 
     def test_negative_hit_w_regex(self):
         schema = {
@@ -170,7 +170,7 @@ class ExtractorTest(TestCase):
 
         ibl_extractor = SlybotIBLExtractor([
             (self.template, {'#default': descriptor}, '0.12.0')])
-        self.assertEqual(ibl_extractor.extract(self.target)[0][0].dump()['gender'], [u'Male'])
+        self.assertEqual(ibl_extractor.extract(self.target)[0][0]['gender'], [u'Male'])
 
     def test_type_extractor(self):
         schema = {
@@ -191,7 +191,7 @@ class ExtractorTest(TestCase):
 
         ibl_extractor = SlybotIBLExtractor([
             (self.template, {'#default': descriptor}, '0.12.0')])
-        self.assertEqual(ibl_extractor.extract(self.target)[0][0].dump()['gender'], [u'Male'])
+        self.assertEqual(ibl_extractor.extract(self.target)[0][0]['gender'], [u'Male'])
 
     def test_default_type_extractor(self):
         schema = {
@@ -205,7 +205,7 @@ class ExtractorTest(TestCase):
 
         ibl_extractor = SlybotIBLExtractor([
             (self.template, {'#default': descriptor}, '0.12.0')])
-        self.assertEqual(ibl_extractor.extract(self.target)[0][0].dump()['gender'], [u'Male'])
+        self.assertEqual(ibl_extractor.extract(self.target)[0][0]['gender'], [u'Male'])
 
     def test_text_type_w_regex_and_no_groups(self):
         schema = {
@@ -225,7 +225,7 @@ class ExtractorTest(TestCase):
 
         ibl_extractor = SlybotIBLExtractor([
             (self.template, {'#default': descriptor}, '0.12.0')])
-        self.assertEqual(ibl_extractor.extract(self.target)[0][0].dump()['gender'], [u'Gender'])
+        self.assertEqual(ibl_extractor.extract(self.target)[0][0]['gender'], [u'Gender'])
 
     def test_extractor_w_empty_string_extraction(self):
         schema = {
@@ -252,7 +252,7 @@ class ExtractorTest(TestCase):
 
         ibl_extractor = SlybotIBLExtractor([
             (self.template2, {'#default': descriptor}, '0.12.0')])
-        self.assertEqual(ibl_extractor.extract(self.target2)[0][0].dump()['name'], [u'Name Olivia'])
+        self.assertEqual(ibl_extractor.extract(self.target2)[0][0]['name'], [u'Name Olivia'])
 
     def test_per_annotation_extractors(self):
         schema = {
@@ -304,5 +304,5 @@ class ExtractorTest(TestCase):
                   'name': [u'Olivia'], 'url': [u'http://www.test.com/olivia'],
                   'title': [u'Name: Olivia'], 'price': [u'2016'],
                   'date': [datetime(2016, 3, 17, 20, 25)]}
-        data = ibl_extractor.extract(self.target3)[0][0].dump()
+        data = ibl_extractor.extract(self.target3)[0][0]
         self.assertEqual(data, result)

--- a/slybot/slybot/tests/test_multiple_item_extraction.py
+++ b/slybot/slybot/tests/test_multiple_item_extraction.py
@@ -152,7 +152,6 @@ class ContainerExtractorTest(TestCase):
     def test_validate_and_adapt_item(self):
         bce = BaseContainerExtractor(basic_extractors, template)
         data = {'price': ['10']}
-        self.assertEqual(bce._validate_and_adapt_item(data, template), {})
         data['_type'] = 'skip_checks'
         result = bce._validate_and_adapt_item(data, template).dump()
         self.assertEqual(result,
@@ -167,8 +166,6 @@ class ContainerExtractorTest(TestCase):
         extracted = bce._validate_and_adapt_item(data, template).dump()
         self.assertEqual(extracted,
                          result)
-        bce.extra_requires = ['pid']
-        self.assertEqual(bce._validate_and_adapt_item(data, template), {})
         data['pid'] = ['13532']
         result = data.copy()
         result['_type'] = 'default'
@@ -251,14 +248,14 @@ class ContainerExtractorTest(TestCase):
             'address': {'type': 'text', 'required': False, 'vary': False}}})}
         add_extractors_to_descriptors(descriptors, extractors)
         extractor = SlybotIBLExtractor([(sample_411, descriptors, '0.13.0')])
-        data = extractor.extract(page_411)[0][1].dump()
+        data = extractor.extract(page_411)[0][1]
         self.assertEqual(data['full_name'], [u'Joe Smith'])
         self.assertEqual(data[u'prénom'], [u'Joe'])
         self.assertEqual(data['nom'], [u'Smith'])
 
     def test_extract_missing_schema(self):
         extractor = SlybotIBLExtractor([(sample_411, {}, '0.13.0')])
-        data = extractor.extract(page_411)[0][1].dump()
+        data = extractor.extract(page_411)[0][1]
         raw_html = ('<span itemprop="name"><span itemprop="givenName">Joe'
                     '</span> <span itemprop="familyName">Smith</span></span>')
         self.assertEqual(data['full_name'], [raw_html])
@@ -319,13 +316,11 @@ class ContainerExtractorTest(TestCase):
             (simple_template, simple_descriptors, '0.13.0')
         ])
         data, _ = ibl_extractor.extract(target1)
-        data = [i.dump() for i in data]
         self.assertEqual(len(data), 10)
         self.assertTrue(all('rank' in item and item['rank'] for item in data))
         self.assertTrue(all('description' in item and item['description']
                             for item in data))
         data, _ = ibl_extractor.extract(target2)
-        data = [i.dump() for i in data]
         self.assertEqual(len(data), 5)
         self.assertTrue(all('rank' in item and item['rank'] for item in data))
         self.assertTrue(all('description' in item and item['description']


### PR DESCRIPTION
    Handle required fields from schemas in item processor
    
    Extract CSS and XPath in the SlybotIBLExtractor
    Run item validation in the SlybotIBLExtractor
    
    By running validation and selector extractors within the IBLE if no valid items
    are extracted using the current sample another one can be tried. This approach
    also allows for Container extractors to have nested Containers where not all
    required fields need to be present in the primary Container.
