### PR TITLE
PORTIA-697: Fix Sentry errors

### DIFF
--- a/portiaui/app/components/browser-iframe.js
+++ b/portiaui/app/components/browser-iframe.js
@@ -272,9 +272,11 @@ const BrowserIFrame = Ember.Component.extend({
     },
 
     iframeSize() {
-        var iframeWindow = this.element.contentWindow;
-        if (iframeWindow) {
-            return iframeWindow.innerWidth + 'x' + iframeWindow.innerHeight;
+        const iframe = Ember.$(this.element);
+        const height = Math.max(iframe.innerHeight(), 10);
+
+        if (iframe) {
+            return iframe.innerWidth() + 'x' + height;
         }
         return null;
     }

--- a/portiaui/app/components/element-overlay.js
+++ b/portiaui/app/components/element-overlay.js
@@ -8,7 +8,7 @@ export default Ember.Component.extend({
     tagName: '',
 
     positionMode: 'size',  // or 'edges'
-    
+
     init() {
         this._super(...arguments);
         this.set('rects', []);
@@ -54,10 +54,13 @@ export default Ember.Component.extend({
     },
 
     readContainerSize(rects, boundingRect, element) {
-        this.containerSize = {
-            width: element.ownerDocument.defaultView.innerWidth,
-            height: element.ownerDocument.defaultView.innerHeight
-        };
+        const view = element.ownerDocument.defaultView;
+        if (view) {
+            this.containerSize = {
+                width:  view.innerWidth,
+                height: view.innerHeight
+            };
+        }
     },
 
     updatePosition(rects) {

--- a/portiaui/app/services/web-socket.js
+++ b/portiaui/app/services/web-socket.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import config from '../config/environment';
-import { logError, shortGuid } from '../utils/utils';
+import { logError } from '../utils/utils';
 
 const APPLICATION_UNLOADING_CODE = 4001;
 const DEFAULT_RECONNECT_TIMEOUT = 5000;
@@ -163,59 +163,5 @@ export default Ember.Service.extend(Ember.Evented, {
             }
             return this.get('ws').send(data);
         }
-    },
-
-    save: function(type, obj) {
-        var data = {
-            _meta: this._metadata(type),
-            _command: 'saveChanges'
-        };
-        if (obj.serialize) {
-            data[type] = obj.serialize();
-        } else {
-            data[type] = obj;
-        }
-        return this._sendPromise(data);
-    },
-
-    delete: function(type, name) {
-        return this._sendPromise({
-            _meta: this._metadata(type),
-            _command: 'delete',
-            name: name
-        });
-    },
-
-    rename: function(type, from, to) {
-        return this._sendPromise({
-            _meta: this._metadata(type),
-            _command: 'rename',
-            old: from,
-            new: to
-        });
-    },
-
-    _sendPromise: function(data) {
-        var deferred = new Ember.RSVP.defer();
-        if (!data._meta) {
-            data._meta = this._metadata(null);
-        } else if (!data._meta.id) {
-            data._meta.id = shortGuid();
-        }
-        if(this.get('opened')) {
-            this.set('deferreds.' + data._meta.id, deferred);
-            this.send(data);
-        } else {
-            deferred.reject('Websocket is closed');
-        }
-        return deferred.promise;
-    },
-
-    _metadata: function(type) {
-        return {
-            // TODO: send current spider and project?
-            type: type,
-            id: shortGuid()
-        };
     }
 });

--- a/slyd/slyd/splash/commands.py
+++ b/slyd/slyd/splash/commands.py
@@ -90,12 +90,6 @@ def _update_sample(data, socket, sample=None, project=None, save=False,
 
 
 def update_spider(data, socket, spider=None):
-    if not socket.spiderspec:
-        return
-    if spider is None:
-        spider = socket.spiderspec.project.spiders[data['spider']].dump()
-    socket.spider._configure_js(spider, _SETTINGS)
-    socket.spider.plugins['Annotations'].build_url_filter(spider)
     return extract(socket)
 
 


### PR DESCRIPTION
- Instead of accessing `element.contentWindow`, calculate the `iframe` dimensions using jQuery (bypasses security error)
- Check `element.ownerDocument.defaultView` in order to avoid `innerWidth` called on undefined.
- Eliminate dead code for the `web-socket` service and `update_spider` in slyd.