### PR TITLE
Compile sample using rendered or original html depending on js status

### DIFF
--- a/slybot/slybot/plugins/scrapely_annotations/annotations.py
+++ b/slybot/slybot/plugins/scrapely_annotations/annotations.py
@@ -31,11 +31,12 @@ class Annotations(object):
     Base Class for adding plugins to Portia Web and Slybot.
     """
 
-    def setup_bot(self, settings, spec, items, extractors, logger):
+    def setup_bot(self, settings, spider, spec, items, extractors, logger):
         """
         Perform any initialization needed for crawling using this plugin
         """
         self.logger = logger
+        self.spider = spider
         templates = map(self._get_annotated_template, spec['templates'])
 
         _item_template_pages = sorted((
@@ -114,6 +115,8 @@ class Annotations(object):
     def _get_annotated_template(self, template):
         if (template.get('version', '0.12.0') >= '0.13.0' and
                 not template.get('annotated')):
+            using_js = self.spider._filter_js_urls(template['url'])
+            template['body'] = 'rendered_body' if using_js else 'original_body'
             _build_sample(template)
         return template
 

--- a/slybot/slybot/plugins/scrapely_annotations/builder.py
+++ b/slybot/slybot/plugins/scrapely_annotations/builder.py
@@ -303,6 +303,7 @@ def apply_selector_annotations(annotations, target_page):
         # Create container for repeated field annotation
         if (annotation.get('repeated') and
                 not annotation.get('item_container') and
+                elems is not None and len(elems) and
                 len(annotation.get('annotations')) == 1):
             repeated_parent = add_repeated_field(annotation, elems, page)
             if repeated_parent:

--- a/slybot/slybot/plugins/selectors/__init__.py
+++ b/slybot/slybot/plugins/selectors/__init__.py
@@ -1,6 +1,6 @@
 
 class Selectors(object):
-    def setup_bot(self, settings, spec, items, extractors, logger):
+    def setup_bot(self, settings, spider, spec, items, extractors, logger):
         self.logger = logger
         self.selectors = {} # { template_id: { field_name: {..} }
 

--- a/slybot/slybot/spider.py
+++ b/slybot/slybot/spider.py
@@ -46,9 +46,9 @@ class IblSpider(SitemapSpider):
         super(IblSpider, self).__init__(name, **kw)
         spec = deepcopy(spec)
         self._add_spider_args_to_spec(spec, kw)
+        self._configure_js(spec, settings)
         self.plugins = self._configure_plugins(
             settings, spec, item_schemas, all_extractors)
-        self._configure_js(spec, settings)
 
         self.login_requests, self.form_requests = [], []
         self._start_urls = self._create_start_urls(spec)
@@ -212,7 +212,8 @@ class IblSpider(SitemapSpider):
         for plugin_class, plugin_name in zip(load_plugins(settings),
                                              load_plugin_names(settings)):
             instance = plugin_class()
-            instance.setup_bot(settings, spec, schemas, extractors, self.logger)
+            instance.setup_bot(settings, self, spec, schemas, extractors,
+                               self.logger)
             plugins[plugin_name] = instance
         return plugins
 

--- a/slybot/slybot/starturls/__init__.py
+++ b/slybot/slybot/starturls/__init__.py
@@ -31,7 +31,7 @@ class StartUrlCollection(object):
         return list(set(chain(*domains)))
 
     def normalize(self):
-        return (start_url.normalized for start_url in self.start_urls)
+        return [start_url.normalized for start_url in self.start_urls]
 
     def _generate_urls(self, start_url):
         generator = self.generators[start_url.generator_type]


### PR DESCRIPTION
Remove dependance on `body` field for compiling sample for js support
Check that elems exist when building repeated field annotation