### PR TITLE
PORTIA-701 PORTIA-702 Browser back button loading

### DIFF
--- a/portiaui/app/components/edit-sample-button.js
+++ b/portiaui/app/components/edit-sample-button.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+const { computed } = Ember;
 import {
     computedCanAddSample,
     computedEditableSample
@@ -13,6 +14,9 @@ export default Ember.Component.extend({
     spider: null,
 
     canAddSample: computedCanAddSample('spider'),
+    disableSample: computed('canAddSample', 'browser.invalidUrl', function() {
+        return !this.get('canAddSample') || this.get('browser.invalidUrl');
+    }),
     editableSample: computedEditableSample('spider'),
     startUrlDomains: Ember.computed('spider.startUrls', function() {
         let startUrlDomains = new Set();

--- a/portiaui/app/components/extracted-items-panel.js
+++ b/portiaui/app/components/extracted-items-panel.js
@@ -5,7 +5,8 @@ export default Ember.Component.extend({
     tagName: '',
 
     extractedItems: service(),
-    isExtracting: computed.alias('extractedItems.isExtracting'),
-    notExtracting: computed.not('isExtracting'),
-    notReadyForExtraction: computed.alias('extractedItems.notReadyForExtraction')
+
+    isExtracting: computed.readOnly('extractedItems.isExtracting'),
+    failedMsg: computed.readOnly('extractedItems.failedExtractionMsg'),
+    failedExtraction: computed.readOnly('extractedItems.failedExtraction')
 });

--- a/portiaui/app/components/show-links-button.js
+++ b/portiaui/app/components/show-links-button.js
@@ -1,6 +1,10 @@
 import Ember from 'ember';
+const { computed, inject: { service } } = Ember;
 
 export default Ember.Component.extend({
+    browser: service(),
+
+    disableLinks: computed.readOnly('browser.invalidUrl'),
     spider: null,
 
     actions: {

--- a/portiaui/app/services/dispatcher.js
+++ b/portiaui/app/services/dispatcher.js
@@ -34,13 +34,6 @@ export function computedEditableSample(spiderPropertyName) {
     });
 }
 
-export function computedCanAddStartUrl(spiderPropertyName) {
-    return Ember.computed('browser.url', `${spiderPropertyName}.startUrls.[]`, function() {
-        const url = this.get('browser.url');
-        return url && !this.get(`${spiderPropertyName}.startUrls`).includes(url);
-    });
-}
-
 export default Ember.Service.extend({
     api: Ember.inject.service(),
     browser: Ember.inject.service(),

--- a/portiaui/app/templates/components/add-start-url-button.hbs
+++ b/portiaui/app/templates/components/add-start-url-button.hbs
@@ -1,7 +1,7 @@
 {{#tooltip-container tooltipFor="start-url-button" tooltipContainer='body' as |options|}}
     {{#if (eq options.section 'tooltip')}}
         Toggle start page
-        {{#if canAddStartUrl}}
+        {{#if newStartUrl}}
             <p>
                 Add this page as a start page for your spider
             </p>
@@ -11,7 +11,7 @@
             </p>
         {{/if}}
     {{else}}
-        <button id="start-url-button" type="button" class="btn btn-default {{if (not canAddStartUrl) 'active'}}" disabled={{not browser.url}} {{action "toggleStartUrl"}}>
+        <button id="start-url-button" type="button" class="btn btn-default {{if (not newStartUrl) 'active'}}" disabled={{disableStartUrl}} {{action "toggleStartUrl"}}>
             {{icon-button icon='url'}} Start page
         </button>
     {{/if}}

--- a/portiaui/app/templates/components/edit-sample-button.hbs
+++ b/portiaui/app/templates/components/edit-sample-button.hbs
@@ -14,7 +14,7 @@
                 {{/unless}}
             {{/unless}}
         {{else}}
-            <button id="add-spider-browser-button" type="button" class="btn btn-primary" disabled={{not canAddSample}} {{action "addSample"}}>
+            <button id="add-spider-browser-button" type="button" class="btn btn-primary" disabled={{disableSample}} {{action "addSample"}}>
                 {{icon-button icon='sample'}} New sample
             </button>
         {{/if}}

--- a/portiaui/app/templates/components/extracted-items-panel.hbs
+++ b/portiaui/app/templates/components/extracted-items-panel.hbs
@@ -5,11 +5,13 @@
     <div class="mid-align one-half-x spaced">Extracting data...</div>
 {{/if}}
 
-{{#if (and notReadyForExtraction notExtracting)}}
+{{#if failedExtraction}}
     <div class="mid-align twice-x spaced">
       <span class="fa fa-ban"></span>
     </div>
-    <div class="mid-align one-half-x spaced">Samples are needed for extracting data.</div>
+    <div class="mid-align one-half-x spaced">
+      {{failedMsg}}
+    </div>
 {{/if}}
 
 {{#if (and selected (not isExtracting))}}

--- a/portiaui/app/templates/components/show-links-button.hbs
+++ b/portiaui/app/templates/components/show-links-button.hbs
@@ -1,5 +1,5 @@
 {{#tooltip-container tooltipFor="show-links-button" text="Toggle link highlighting" tooltipContainer='body' as |options|}}
-    <button id="show-links-button" class="btn btn-default {{if spider.showLinks 'active'}}" {{action 'toggleShowLinks'}}>
+    <button id="show-links-button" class="btn btn-default {{if spider.showLinks 'active'}}" disabled={{disableLinks}} {{action 'toggleShowLinks'}}>
         {{icon-button icon='link'}}
     </button>
 {{/tooltip-container}}

--- a/slyd/slyd/splash/ferry.py
+++ b/slyd/slyd/splash/ferry.py
@@ -197,8 +197,7 @@ class PortiaJSApi(QObject):
             print '----------------------------------'
             print 'COMMAND: mutation + metadata'
             print '----------------------------------'
-            with data_store_context():
-                self.protocol.sendMessage(metadata(self.protocol))
+            self.protocol.sendMessage(metadata(self.protocol))
 
 
 class FerryServerProtocol(WebSocketServerProtocol):


### PR DESCRIPTION
* `Start Page`, `Sample button` and `Toggle Links` buttons are now disabled if the user goes to an invalid url
* Fixed invalid url state by interacting with the browser to display the error and showing an error in the extraction pane as well
* Remove `data_store_context` in the case of the mutation as this would raise errors unnecessarily when coupling two websocket events