### PR TITLE
Project route does not load all spider json files

### DIFF
--- a/portia_server/portia_api/jsonapi/relationships.py
+++ b/portia_server/portia_api/jsonapi/relationships.py
@@ -7,9 +7,13 @@ from portia_api.jsonapi.utils import (
 
 
 class Relationship(BaseRelationship):
+    def __init__(self, **kwargs):
+        self._serializer = kwargs.get('serializer')
+        super(Relationship, self).__init__(**kwargs)
+
     @cached_property
     def schema(self):
-        schema = get_schema(self.type_)
+        schema = self._serializer or get_schema(self.type_)
         return schema(fields_map=self.root.fields_map,
                       exclude_map=self.root.exclude_map,
                       include_data=self.root.include_map.get(self.name, []),

--- a/portia_server/portia_api/resources/serializers.py
+++ b/portia_server/portia_api/resources/serializers.py
@@ -17,6 +17,17 @@ def clear_auto_created(instance):
         instance.save(only=('auto_created',))
 
 
+class SpiderListSerializer(JsonApiSerializer):
+    class Meta:
+        model = Spider
+        url = '/api/projects/{self.project.id}/spiders/{self.id}'
+        links = {
+            'project': {
+                'related': '/api/projects/{self.project.id}',
+            },
+        }
+
+
 class ProjectSerializer(JsonApiSerializer):
     class Meta:
         model = Project
@@ -24,6 +35,7 @@ class ProjectSerializer(JsonApiSerializer):
         links = {
             'spiders': {
                 'related': '/api/projects/{self.id}/spiders',
+                'serializer': SpiderListSerializer,
             },
             'schemas': {
                 'related': '/api/projects/{self.id}/schemas',

--- a/portia_server/storage/backends.py
+++ b/portia_server/storage/backends.py
@@ -1,5 +1,6 @@
 import errno
 import json
+import logging
 import os
 import os.path
 import re
@@ -17,6 +18,9 @@ from six import iteritems, text_type, string_types
 
 from .projecttemplates import templates
 from .repoman import Repoman, DEFAULT_USER, FILE_MODE
+
+
+logger = logging.getLogger(__name__)
 
 
 class InvalidFilename(Exception):
@@ -212,6 +216,7 @@ class GitStorage(BasePortiaStorage):
 
     def _open(self, name, mode='rb'):
         name = self.path(name)
+        logger.debug('Dulwich open: {}'.format(name))
         if self.isfile(name):
             _, sha = self._working_tree[name]
             if sha in self._blobs:


### PR DESCRIPTION
Opening a project with many spiders in Portia became inefficient because Dulwich was opening all spider json files. Using a custom serializer `SpiderListSerializer`, we avoid this issue by not having including the related samples in the `links` property in `Meta`.
In order to do use a custom serializer:
- The serializer class must be provided in the `links` property to use the custom serializer

Additional debug logging was introduced in the `Gitstorage` backend to properly debug this issue.