### PR TITLE
Fix how tables are handled in sample migration

### DIFF
--- a/slybot/slybot/tests/test_migration.py
+++ b/slybot/slybot/tests/test_migration.py
@@ -1,0 +1,33 @@
+import unittest
+
+from slybot.plugins.scrapely_annotations.migration import handle_tables
+
+
+class MigrationTests(unittest.TestCase):
+    def test_table_generalization(self):
+        selectors = [
+            ('table.mainbg > tr:nth-child(5) > td:nth-child(1) > '
+             'table:nth-child(2) > tr:nth-child(3) > td:nth-child(1) > '
+             'p:nth-child(1) > strong:nth-child(1)',
+             'table.mainbg > tr:nth-child(5) > td:nth-child(1) > '
+             'table:nth-child(2) > tr:nth-child(3) > td:nth-child(1) > '
+             'p:nth-child(1) > strong:nth-child(1), table.mainbg > * > '
+             'tr:nth-child(5) > td:nth-child(1) > table:nth-child(2) > '
+             'tr:nth-child(3) > td:nth-child(1) > p:nth-child(1) > '
+             'strong:nth-child(1), table.mainbg > tr:nth-child(5) > '
+             'td:nth-child(1) > table:nth-child(2) > * > tr:nth-child(3) > '
+             'td:nth-child(1) > p:nth-child(1) > strong:nth-child(1), '
+             'table.mainbg > * > tr:nth-child(5) > td:nth-child(1) > '
+             'table:nth-child(2) > * > tr:nth-child(3) > td:nth-child(1) > '
+             'p:nth-child(1) > strong:nth-child(1)'),
+            ('div > p > .table > div > span', 'div > p > .table > div > span'),
+            ('div > p > #table > div > span', 'div > p > #table > div > span'),
+            ('div > p > table > div > span',
+             'div > p > table > div > span, div > p > table > * > div > span'),
+            ('div > p > table:nth-child(4) > div > span',
+             'div > p > table:nth-child(4) > div > span, '
+             'div > p > table:nth-child(4) > * > div > span'),
+            ('table', 'table')
+        ]
+        for selector, generalized in selectors:
+            self.assertEqual(handle_tables(selector), generalized)


### PR DESCRIPTION
Tables are now handled by changing all instances of table selectors to:

`table > * > div, table > div`

This allows a table to handle the existence, or not, of a tbody, thead or tfoot