### PR TITLE
Normalize exceptions for JsonApiRoute

### DIFF
--- a/portia_server/portia_api/jsonapi/exceptions.py
+++ b/portia_server/portia_api/jsonapi/exceptions.py
@@ -22,13 +22,15 @@ class JsonApiValidationError(ValidationError):
         })
 
 
-def render_exception(exc):
-    return OrderedDict([
-        ('id', str(uuid4())),
-        ('status', exc.status_code),
-        ('title', get_status_title(exc.status_code)),
-        ('detail', exc.detail)
-    ])
+def render_exception(status_code, detail):
+    return {
+        'errors': [OrderedDict([
+            ('id', str(uuid4())),
+            ('status', status_code),
+            ('title', get_status_title(status_code)),
+            ('detail', detail)
+        ])]
+    }
 
 
 class JsonApiBadRequestError(APIException):
@@ -62,7 +64,7 @@ def jsonapi_exception_handler(exc, context):
     accepts = context['request'].accepted_media_type or ''
     if accepts.startswith('application/vnd.api+json'):
         try:
-            exc.detail = {'errors': [render_exception(exc)]}
+            exc.detail = render_exception(exc.status_code, exc.detail)
         except AttributeError:
             pass  # Ignore django exceptions
     response = exception_handler(exc, context)

--- a/portia_server/portia_api/resources/route.py
+++ b/portia_server/portia_api/resources/route.py
@@ -20,7 +20,8 @@ from portia_orm.relationships import BelongsTo, HasMany
 from storage import create_project_storage
 from ..jsonapi.exceptions import (JsonApiBadRequestError,
                                   JsonApiConflictError,
-                                  JsonApiValidationError)
+                                  JsonApiValidationError,
+                                  render_exception)
 from ..jsonapi.parsers import JSONApiParser, JSONParser
 from ..jsonapi.registry import get_schema
 from ..jsonapi.renderers import JSONApiRenderer, JSONRenderer
@@ -79,12 +80,7 @@ class JsonApiRoute(ViewSet):
         status_code = response.status_code
         if (isinstance(response.data, dict) and len(response.data) == 1 and
                 'detail' in response.data):
-            status_title = get_status_title(status_code)
-            response.data = OrderedDict([
-                ('status', text_type(status_code)),
-                ('title', status_title),
-                ('detail', response.data['detail']),
-            ])
+            response.data = render_exception(status_code, response.data['detail'])
         return response
 
     def get_instance(self):


### PR DESCRIPTION
`JsonApiRoute` was not returning a payload in the correct format for the Ember Adapter to properly show in the UI. Normalized responses and generalized the `render_exception` function.