### PR TITLE
Update extract endpoint to allow multiple results per request.

### DIFF
--- a/portia_server/portia_orm/models.py
+++ b/portia_server/portia_orm/models.py
@@ -420,8 +420,8 @@ class Sample(Model, OrderedAnnotationsMixin):
         if items:
             return data
 
-        json_file = self.context['storage'].open_with_default('extractors.json')
-        extractors = json.load(json_file)
+        extractors = json.loads(self.context['storage'].open_with_default(
+            'extractors.json', {}))
         sample, new_schemas = port_sample(data, schemas, extractors)
         self._add_schemas(self, new_schemas)
         self.save_raw(self, sample)


### PR DESCRIPTION
Fix loading external html for sample

To use the extract endpoint:
```python
import requests
requests.post('portia:9001/api/projects/PROJECT/spiders/SPIDER/extract',
              json=['http://example1.com', 'http://exampe2.com'])
```
