### PR TITLE
Small Fixes for bugs

### DIFF
--- a/portia_server/portia_api/resources/models.py
+++ b/portia_server/portia_api/resources/models.py
@@ -149,7 +149,6 @@ class SpiderSchema(SlydSchema):
     login_user = fields.Str()
     login_password = fields.Str()
     perform_login = fields.Boolean(default=False)
-    template_names = fields.List(fields.Str(), default=[])
     samples = fields.Relationship(
         related_url='/api/projects/{project_id}/spider/{spider_id}/samples',
         related_url_kwargs={'project_id': '<project_id>',

--- a/portia_server/portia_api/resources/serializers.py
+++ b/portia_server/portia_api/resources/serializers.py
@@ -9,6 +9,7 @@ from portia_orm.models import (Project, Schema, Field, Extractor, Spider,
                                Sample, Item, Annotation, RenderedBody,
                                OriginalBody)
 from portia_api.utils.projects import unique_name
+from portia_api.utils.annotations import choose_field_type
 
 
 def clear_auto_created(instance):
@@ -332,7 +333,8 @@ class AnnotationSerializer(JsonApiSerializer):
             field_names = map(attrgetter('name'), schema.fields)
             field_name = unique_name('field', field_names, initial_suffix=1)
             field = Field(self.storage, id=AUTO_PK, name=field_name,
-                          schema=schema, auto_created=True)
+                          type=choose_field_type(annotation), schema=schema,
+                          auto_created=True)
             field.annotations.add(annotation)
             field.save()
 

--- a/portia_server/portia_api/utils/annotations.py
+++ b/portia_server/portia_api/utils/annotations.py
@@ -1,0 +1,30 @@
+
+DEFAULTS = {
+    'accept': 'url',
+    'align': 'number',
+    'code': 'url',
+    'codebase': 'url',
+    'coords': 'geopoint',
+    'data': 'url',
+    'datetime': 'date',
+    'download': 'url',
+    'high': 'number',
+    'href': 'url',
+    'icon': 'image',
+    'low': 'number',
+    'max': 'number',
+    'media': 'href',
+    'min': 'number',
+    'optimum': 'number',
+    'rel': 'href',
+    'rows': 'number',
+    'src': 'image',
+    'target': 'url',
+}
+
+
+def choose_field_type(annotation):
+    attribute = annotation.attribute
+    if attribute == 'content':
+        return 'text'
+    return DEFAULTS.get(attribute, 'text')

--- a/portia_server/portia_api/utils/extract.py
+++ b/portia_server/portia_api/utils/extract.py
@@ -109,7 +109,10 @@ def load_spider(storage, model):
     for sample in model.samples:
         json_sample = json.loads(sample.dumps())
         json_sample['original_body'] = sample.original_body.html
-        json_sample['rendered_body'] = sample.original_body.html
+        try:
+            json_sample['rendered_body'] = sample.original_body.html
+        except IOError:
+            json_sample['rendered_body'] = json_sample['original_body']
         samples.append(json_sample)
     spider['templates'] = samples
     return IblSpider(model.id, spider, items, extractors, Settings())

--- a/portia_server/portia_orm/tests/test_model.py
+++ b/portia_server/portia_orm/tests/test_model.py
@@ -1295,7 +1295,6 @@ class SpiderTests(ProjectTestCase):
             'js_enabled': False,
             'js_enable_patterns': [],
             'js_disable_patterns': [],
-            'template_names': [],
         })
 
     def test_full_spider(self):
@@ -1351,9 +1350,6 @@ class SpiderTests(ProjectTestCase):
                     'password': 'pass'
                 }
             ],
-            'template_names': [
-                'sample-1',
-            ],
         })
 
     def test_links_to_follow(self):
@@ -1402,9 +1398,6 @@ class SpiderTests(ProjectTestCase):
                         "password": "pass"
                     }
                 ],
-                "template_names": [
-                    "1ddc-4043-ac4d"
-                ]
             },
         ])
         self.storage.open.assert_called_once_with('spiders/shop-crawler.json')
@@ -1434,9 +1427,6 @@ class SpiderTests(ProjectTestCase):
                     "password": "pass"
                 }
             ],
-            "template_names": [
-                "1ddc-4043-ac4d"
-            ]
         })
         self.storage.open.assert_called_once_with('spiders/shop-crawler.json')
 
@@ -1480,9 +1470,6 @@ class SpiderTests(ProjectTestCase):
             '            "url": "http://example.com/", \n'
             '            "type": "url"\n'
             '        }\n'
-            '    ], \n'
-            '    "template_names": [\n'
-            '        "1ddc-4043-ac4d"\n'
             '    ]\n'
             '}')
 
@@ -1529,9 +1516,6 @@ class SpiderTests(ProjectTestCase):
             '            "url": "http://example.com/", \n'
             '            "type": "url"\n'
             '        }\n'
-            '    ], \n'
-            '    "template_names": [\n'
-            '        "1ddc-4043-ac4d"\n'
             '    ]\n'
             '}')
 
@@ -1555,8 +1539,7 @@ class SpiderTests(ProjectTestCase):
             '    "js_enabled": false, \n'
             '    "links_to_follow": "all", \n'
             '    "respect_nofollow": true, \n'
-            '    "start_urls": [], \n'
-            '    "template_names": []\n'
+            '    "start_urls": []\n'
             '}')
 
         project.spiders.insert(0, Spider(self.storage, id='test2'))
@@ -1579,8 +1562,7 @@ class SpiderTests(ProjectTestCase):
             '    "js_enabled": false, \n'
             '    "links_to_follow": "all", \n'
             '    "respect_nofollow": true, \n'
-            '    "start_urls": [], \n'
-            '    "template_names": []\n'
+            '    "start_urls": []\n'
             '}')
 
     def test_delete(self):
@@ -2144,9 +2126,6 @@ class SampleTests(ProjectTestCase):
             '            "url": "http://example.com/", \n'
             '            "type": "url"\n'
             '        }\n'
-            '    ], \n'
-            '    "template_names": [\n'
-            '        "test-id"\n'
             '    ]\n'
             '}')
 
@@ -2180,37 +2159,6 @@ class SampleTests(ProjectTestCase):
             '    "url": "http://example.com/test1", \n'
             '    "version": "' + SLYBOT_VERSION + '"\n'
             '}')
-        self.assertEqual(
-            self.storage.files['spiders/shop-crawler.json'],
-            '{\n'
-            '    "allowed_domains": [], \n'
-            '    "exclude_patterns": [], \n'
-            '    "follow_patterns": [], \n'
-            '    "id": "shop-crawler", \n'
-            '    "init_requests": [\n'
-            '        {\n'
-            '            "type": "login", \n'
-            '            "loginurl": "http://shop.example.com/login", \n'
-            '            "username": "user", \n'
-            '            "password": "pass"\n'
-            '        }\n'
-            '    ], \n'
-            '    "js_disable_patterns": [], \n'
-            '    "js_enable_patterns": [], \n'
-            '    "js_enabled": false, \n'
-            '    "links_to_follow": "all", \n'
-            '    "respect_nofollow": true, \n'
-            '    "start_urls": [\n'
-            '        {\n'
-            '            "url": "http://example.com/", \n'
-            '            "type": "url"\n'
-            '        }\n'
-            '    ], \n'
-            '    "template_names": [\n'
-            '        "1ddc-4043-ac4d", \n'
-            '        "test1"\n'
-            '    ]\n'
-            '}')
 
         spider.samples.insert(0, Sample(self.storage, id='test2',
                                         name='test sample 2',
@@ -2241,38 +2189,6 @@ class SampleTests(ProjectTestCase):
             '    "spider": "shop-crawler", \n'
             '    "url": "http://example.com/test2", \n'
             '    "version": "' + SLYBOT_VERSION + '"\n'
-            '}')
-        self.assertEqual(
-            self.storage.files['spiders/shop-crawler.json'],
-            '{\n'
-            '    "allowed_domains": [], \n'
-            '    "exclude_patterns": [], \n'
-            '    "follow_patterns": [], \n'
-            '    "id": "shop-crawler", \n'
-            '    "init_requests": [\n'
-            '        {\n'
-            '            "type": "login", \n'
-            '            "loginurl": "http://shop.example.com/login", \n'
-            '            "username": "user", \n'
-            '            "password": "pass"\n'
-            '        }\n'
-            '    ], \n'
-            '    "js_disable_patterns": [], \n'
-            '    "js_enable_patterns": [], \n'
-            '    "js_enabled": false, \n'
-            '    "links_to_follow": "all", \n'
-            '    "respect_nofollow": true, \n'
-            '    "start_urls": [\n'
-            '        {\n'
-            '            "url": "http://example.com/", \n'
-            '            "type": "url"\n'
-            '        }\n'
-            '    ], \n'
-            '    "template_names": [\n'
-            '        "test2", \n'
-            '        "1ddc-4043-ac4d", \n'
-            '        "test1"\n'
-            '    ]\n'
             '}')
 
     def test_delete(self):
@@ -2319,8 +2235,7 @@ class SampleTests(ProjectTestCase):
             '            "url": "http://example.com/", \n'
             '            "type": "url"\n'
             '        }\n'
-            '    ], \n'
-            '    "template_names": []\n'
+            '    ]\n'
             '}')
         self.assertEqual(
             self.storage.files['items.json'],
@@ -2896,7 +2811,8 @@ class ItemTests(ProjectTestCase):
         self.assertEqual(self.storage.open.call_count, 4)
         self.storage.open.assert_has_calls([
             mock.call('spiders/shop-crawler.json'),
-            mock.call('spiders/shop-crawler/1ddc-4043-ac4d.json')])
+            mock.call('spiders/shop-crawler/1ddc-4043-ac4d.json'),
+            mock.call('items.json')])
 
     def test_save_edit(self):
         item = Item(
@@ -2909,7 +2825,8 @@ class ItemTests(ProjectTestCase):
         self.assertEqual(self.storage.open.call_count, 4)
         self.storage.open.assert_has_calls([
             mock.call('spiders/shop-crawler.json'),
-            mock.call('spiders/shop-crawler/1ddc-4043-ac4d.json')])
+            mock.call('spiders/shop-crawler/1ddc-4043-ac4d.json'),
+            mock.call('items.json')])
         self.storage.save.assert_not_called()
 
         item.selector = '#test'
@@ -2918,7 +2835,8 @@ class ItemTests(ProjectTestCase):
         self.assertEqual(self.storage.open.call_count, 4)
         self.storage.open.assert_has_calls([
             mock.call('spiders/shop-crawler.json'),
-            mock.call('spiders/shop-crawler/1ddc-4043-ac4d.json')])
+            mock.call('spiders/shop-crawler/1ddc-4043-ac4d.json'),
+            mock.call('items.json')])
         self.storage.save.assert_called_once_with(
             'spiders/shop-crawler/1ddc-4043-ac4d.json', mock.ANY)
         self.assertEqual(
@@ -3068,7 +2986,8 @@ class ItemTests(ProjectTestCase):
         self.assertEqual(self.storage.open.call_count, 4)
         self.storage.open.assert_has_calls([
             mock.call('spiders/shop-crawler.json'),
-            mock.call('spiders/shop-crawler/1ddc-4043-ac4d.json')])
+            mock.call('spiders/shop-crawler/1ddc-4043-ac4d.json'),
+            mock.call('items.json')])
         self.assertEqual(self.storage.save.call_count, 2)
         self.storage.save.assert_has_calls([
             mock.call('spiders/shop-crawler/1ddc-4043-ac4d.json', mock.ANY),
@@ -3225,7 +3144,8 @@ class ItemTests(ProjectTestCase):
         self.assertEqual(self.storage.open.call_count, 4)
         self.storage.open.assert_has_calls([
             mock.call('spiders/shop-crawler.json'),
-            mock.call('spiders/shop-crawler/1ddc-4043-ac4d.json')])
+            mock.call('spiders/shop-crawler/1ddc-4043-ac4d.json'),
+            mock.call('items.json')])
         self.storage.save.assert_called_once_with(
             'spiders/shop-crawler/1ddc-4043-ac4d.json', mock.ANY)
         self.assertEqual(
@@ -3392,7 +3312,8 @@ class ItemTests(ProjectTestCase):
         self.assertEqual(self.storage.open.call_count, 4)
         self.storage.open.assert_has_calls([
             mock.call('spiders/shop-crawler.json'),
-            mock.call('spiders/shop-crawler/1ddc-4043-ac4d.json')])
+            mock.call('spiders/shop-crawler/1ddc-4043-ac4d.json'),
+            mock.call('items.json')])
         self.assertEqual(self.storage.save.call_count, 2)
         self.storage.save.assert_has_calls([
             mock.call('spiders/shop-crawler/1ddc-4043-ac4d.json', mock.ANY),
@@ -3836,7 +3757,8 @@ class AnnotationTests(ProjectTestCase):
         self.assertEqual(self.storage.open.call_count, 4)
         self.storage.open.assert_has_calls([
             mock.call('spiders/shop-crawler.json'),
-            mock.call('spiders/shop-crawler/1ddc-4043-ac4d.json')])
+            mock.call('spiders/shop-crawler/1ddc-4043-ac4d.json'),
+            mock.call('items.json')])
 
     def test_save_edit(self):
         annotation = Annotation(
@@ -3851,7 +3773,8 @@ class AnnotationTests(ProjectTestCase):
         self.assertEqual(self.storage.open.call_count, 4)
         self.storage.open.assert_has_calls([
             mock.call('spiders/shop-crawler.json'),
-            mock.call('spiders/shop-crawler/1ddc-4043-ac4d.json')])
+            mock.call('spiders/shop-crawler/1ddc-4043-ac4d.json'),
+            mock.call('items.json')])
         self.storage.save.assert_not_called()
 
         annotation.selector = '.test'
@@ -3860,7 +3783,8 @@ class AnnotationTests(ProjectTestCase):
         self.assertEqual(self.storage.open.call_count, 4)
         self.storage.open.assert_has_calls([
             mock.call('spiders/shop-crawler.json'),
-            mock.call('spiders/shop-crawler/1ddc-4043-ac4d.json')])
+            mock.call('spiders/shop-crawler/1ddc-4043-ac4d.json'),
+            mock.call('items.json')])
         self.storage.save.assert_called_once_with(
             'spiders/shop-crawler/1ddc-4043-ac4d.json', mock.ANY)
         self.assertEqual(
@@ -3971,7 +3895,8 @@ class AnnotationTests(ProjectTestCase):
         self.assertEqual(self.storage.open.call_count, 4)
         self.storage.open.assert_has_calls([
             mock.call('spiders/shop-crawler.json'),
-            mock.call('spiders/shop-crawler/1ddc-4043-ac4d.json')])
+            mock.call('spiders/shop-crawler/1ddc-4043-ac4d.json'),
+            mock.call('items.json')])
         self.assertEqual(self.storage.save.call_count, 2)
         self.storage.save.assert_has_calls([
             mock.call('spiders/shop-crawler/1ddc-4043-ac4d.json', mock.ANY),
@@ -4090,7 +4015,8 @@ class AnnotationTests(ProjectTestCase):
         self.assertEqual(self.storage.open.call_count, 4)
         self.storage.open.assert_has_calls([
             mock.call('spiders/shop-crawler.json'),
-            mock.call('spiders/shop-crawler/1ddc-4043-ac4d.json')])
+            mock.call('spiders/shop-crawler/1ddc-4043-ac4d.json'),
+            mock.call('items.json')])
         self.storage.save.assert_called_once_with(
             'spiders/shop-crawler/1ddc-4043-ac4d.json', mock.ANY)
         self.assertEqual(
@@ -4223,7 +4149,8 @@ class AnnotationTests(ProjectTestCase):
         self.assertEqual(self.storage.open.call_count, 4)
         self.storage.open.assert_has_calls([
             mock.call('spiders/shop-crawler.json'),
-            mock.call('spiders/shop-crawler/1ddc-4043-ac4d.json')])
+            mock.call('spiders/shop-crawler/1ddc-4043-ac4d.json'),
+            mock.call('items.json')])
         self.assertEqual(self.storage.save.call_count, 2)
         self.storage.save.assert_has_calls([
             mock.call('spiders/shop-crawler/1ddc-4043-ac4d.json', mock.ANY),

--- a/portia_server/portia_orm/utils.py
+++ b/portia_server/portia_orm/utils.py
@@ -26,6 +26,7 @@ ENCODINGS = ['UTF-8', 'ISO-8859-1', 'Windows-1251', 'Shift JIS',
              'Windows-1252', 'GB2312', 'EUC-KR', 'EUC-JP', 'GBK', 'ISO-8859-2',
              'Windows-1250', 'ISO-8859-15', 'Windows-1256', 'ISO-8859-9',
              'Big5', 'Windows-1254', 'Windows-874']
+JSON_LEN = len('.json')
 
 
 class cached_property_ignore_set(cached_property):
@@ -122,3 +123,9 @@ def _encode_or_decode_string(html, method, default):
             pass
     encoding = chardet.detect(html).get('encoding')
     return method(html, encoding)
+
+
+def strip_json(fname):
+    if fname.endswith('.json'):
+        return fname[:-JSON_LEN]
+    return fname

--- a/portiaui/app/adapters/application.js
+++ b/portiaui/app/adapters/application.js
@@ -1,6 +1,7 @@
 import Ember from "ember";
 import DS from "ember-data";
 import UrlTemplates from "ember-data-url-templates";
+const { inject: { service } } = Ember;
 
 const DELETED_EXTENSION = 'https://portia.scrapinghub.com/jsonapi/extensions/deleted';
 const UPDATES_EXTENSION = 'https://portia.scrapinghub.com/jsonapi/extensions/updates';
@@ -22,8 +23,9 @@ function filter_update_errors(errors, pointer) {
 }
 
 export default DS.JSONAPIAdapter.extend(UrlTemplates, {
-    savingNotification: Ember.inject.service(),
-    uiState: Ember.inject.service(),
+    savingNotification: service(),
+    loadingSlider: service(),
+    uiState: service(),
 
     findRecordUrlTemplate: '{+host}{+selfLink}',
     createRecordUrlTemplate: '{+host}{+relatedLink}',
@@ -371,8 +373,10 @@ export default DS.JSONAPIAdapter.extend(UrlTemplates, {
 
             // update saving status
             this.get('savingNotification').start();
+            this.get('loadingSlider').startLoading();
             promise.finally(() => {
                 this.get('savingNotification').end();
+            this.get('loadingSlider').endLoading();
                 const project = this.get('uiState.models.project');
                 if (project) {
                     project.markChanged();

--- a/portiaui/app/components/browser-iframe.js
+++ b/portiaui/app/components/browser-iframe.js
@@ -59,6 +59,7 @@ const BrowserIFrame = Ember.Component.extend({
         ws.addCommand('load', this, this.msgLoad);
         ws.addCommand('cookies', this, this.msgCookies);
         ws.addCommand('mutation', this, this.msgMutation);
+        ws.addCommand('save_html', this, this.noop);
     },
 
     didInsertElement() {
@@ -78,6 +79,7 @@ const BrowserIFrame = Ember.Component.extend({
         ws.removeCommand('load', this, this.msgLoad);
         ws.removeCommand('cookies', this, this.msgCookies);
         ws.removeCommand('mutation', this, this.msgMutation);
+        ws.removeCommand('save_html', this, this.noop);
         ws.close();
 
         this.setProperties({
@@ -195,6 +197,10 @@ const BrowserIFrame = Ember.Component.extend({
         if (cookies && cookies.length) {
             this.set(`cookiesStore.${cookieId}`, cookies);
         }
+    },
+
+    noop() {
+        return null;
     },
 
     loadCookies(){

--- a/portiaui/app/components/extracted-items-status.js
+++ b/portiaui/app/components/extracted-items-status.js
@@ -1,18 +1,22 @@
 import Ember from 'ember';
+const { computed, inject: { service } } = Ember;
 
 export default Ember.Component.extend({
     tagName: '',
-    extractedItems: Ember.inject.service(),
+    extractedItems: service(),
+    store: service(),
 
-    type: Ember.computed.readOnly('extractedItems.type'),
-    changes: Ember.computed('extractedItems.changes', function() {
-        return this.get('extractedItems.changes') || [];
+    type: computed.readOnly('extractedItems.type'),
+    spider: computed.readOnly('extractedItems.spider'),
+    changes: computed('extractedItems.changes', function() {
+        return (this.get('extractedItems.changes') || []);
+    }),
+    changed: computed('extractedItems.changed', function() {
+        return (this.get('extractedItems.changed') || []);
     }),
 
-    hasChanges: Ember.computed.gt('changes.length', 0),
-
-    hasWarning: Ember.computed('type', 'changes', 'changes.length', function() {
-        let hasChanges = this.get('hasChanges');
+    hasWarning: computed('type', 'changes.[]', function() {
+        let hasChanges = this.get('changes').length > 0;
         if (this.get('type') === 'js') {
             if (hasChanges && this.get('changes')[0] === 'no_items') {
                 return false;
@@ -23,7 +27,51 @@ export default Ember.Component.extend({
         return hasChanges;
     }),
 
-    icon: Ember.computed('hasWarning', function() {
+    change: computed('hasWarning', function() {
+        let change = this.get('changes')[0];
+        return change ? change : 'js_not_required';
+    }),
+
+    changeInfo: computed('change', function() {
+        let change = this.get('change'),
+            changes = this.get('changed'),
+            type = this.get('type');
+        if (change === 'missing_items' || change === 'missing_fields') {
+            // TODO: Properly handle these conditions
+            change = type === 'js' ? 'no_items' : 'js_not_required';
+        }
+        let CHANGES = {
+            js_not_required: {
+                text: `Javascript is enabled for this sample and may not be needed. \
+                       Your spider may run faster if Javascript is not run on pages like this`,
+                path: 'projects.project.spider.options',
+            },
+            no_items: {
+                text: `Javascript is not enabled for this sample. It may extract more accurate \
+                       data if it is enabled`,
+                path: 'projects.project.spider.options',
+            },
+            missing_required_field: {
+                path: 'projects.project.schema.field.options',
+            }
+        };
+        let opts = CHANGES[change];
+        if (!opts) {
+            return {};
+        }
+        if (change === 'missing_required_field') {
+            let field = this.get('store').peekRecord('field', changes[1][0]),
+                text = `The field "${field.get('name')}" is marked as required but there is no \
+                        annotation for that field`;
+            opts.text = text;
+            opts.model = field;
+            return opts;
+        }
+        opts.model = this.get('spider');
+        return opts;
+    }),
+
+    icon: computed('hasWarning', function() {
         return this.get('hasWarning') ? 'warning-triangle' : 'ok';
     }),
 });

--- a/portiaui/app/components/inspector-panel.js
+++ b/portiaui/app/components/inspector-panel.js
@@ -54,12 +54,16 @@ export function getDefaultAttribute(element) {
         return attrList[0].attribute;
     }
 
-    if (attrList.findBy('attribute', 'content')) {
-        return 'content';
-    } else if (element.tagName === 'IMG' && attrList.findBy('attribute', 'src')) {
+    if (attrList.findBy('attribute', 'src')) {
         return 'src';
-    } else if (element.tagName === 'A' && attrList.findBy('attribute', 'href')) {
+    } else if (attrList.findBy('attribute', 'href')) {
         return 'href';
+    } else if (attrList.findBy('attribute', 'datetime')) {
+        return 'datetime';
+    } else if (attrList.findBy('attribute', 'content')) {
+        return 'content';
+    } else if (attrList.length) {
+        return attrList[0].attribute;
     }
 
     return null;

--- a/portiaui/app/components/list-item-link-crawling.js
+++ b/portiaui/app/components/list-item-link-crawling.js
@@ -1,32 +1,41 @@
 import Ember from 'ember';
 import SaveSpiderMixin from '../mixins/save-spider-mixin';
+const { computed, inject: { service } } = Ember;
 
 export default Ember.Component.extend(SaveSpiderMixin, {
-    routing: Ember.inject.service('-routing'),
+    routing: service('-routing'),
     tagName: '',
 
     spider: null,
 
     followPatternOptions: [
         {
+            value: 'auto',
+            label: 'Follow links automatically',
+            description: `Use start urls and sample urls to teach the spider the \
+                          best links to follow`
+        },
+        {
             value: 'all',
-            label: 'Follow all in-domain links'
+            label: 'Follow all in-domain links',
+            description: `Follow all links which have a domain or sub domain that match \
+                          the start or sample urls`
         },
         {
             value: 'none',
-            label: "Don't follow links"
+            label: "Don't follow links",
+            description: `Only attempt to extract data from start urls. Can be combined \
+                          to great effect with feed and generated urls`
         },
         {
             value: 'patterns',
-            label: 'Configure url patterns'
-        },
-        {
-            value: 'auto',
-            label: 'Follow links automatically'
+            label: 'Configure url patterns',
+            description: `Create patterns for the spider to follow or not and direct your \
+                          spider with pin point accuracy`
         },
     ],
 
-    linksToFollow: Ember.computed('spider.linksToFollow', {
+    linksToFollow: computed('spider.linksToFollow', {
         get() {
             return this.followPatternOptions.findBy('value', this.get('spider.linksToFollow'));
         },

--- a/portiaui/app/routes/application.js
+++ b/portiaui/app/routes/application.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+import LoadingSliderMixin from '../mixins/loading-slider';
+
+export default Ember.Route.extend(LoadingSliderMixin, {
+});

--- a/portiaui/app/routes/projects/project/spider/sample/data.js
+++ b/portiaui/app/routes/projects/project/spider/sample/data.js
@@ -1,8 +1,10 @@
 import Ember from 'ember';
+const { inject: { service }, run } = Ember;
 
 export default Ember.Route.extend({
-    annotationStructure: Ember.inject.service(),
-    browser: Ember.inject.service(),
+    annotationStructure: service(),
+    extractedItems: service(),
+    browser: service(),
 
     init() {
         this._super(...arguments);
@@ -15,6 +17,7 @@ export default Ember.Route.extend({
 
     afterModel(model) {
         this.updateDataStructure(model);
+        this.get('extractedItems').update();
     },
 
     activate() {
@@ -26,7 +29,7 @@ export default Ember.Route.extend({
         this.updateDataStructure(null);
 
         if (this.scheduledRenderOverlays) {
-            Ember.run.cancel(this.scheduledRenderOverlays);
+            run.cancel(this.scheduledRenderOverlays);
         }
 
         this.get('browser').clearAnnotationMode();
@@ -49,7 +52,7 @@ export default Ember.Route.extend({
             outlet: 'browser-toolbar'
         });
 
-        this.scheduledRenderOverlays = Ember.run.next(this, this.renderOverlayTemplate);
+        this.scheduledRenderOverlays = run.next(this, this.renderOverlayTemplate);
     },
 
     renderOverlayTemplate() {

--- a/portiaui/app/services/dispatcher.js
+++ b/portiaui/app/services/dispatcher.js
@@ -181,13 +181,13 @@ export default Ember.Service.extend({
                 project: spider.get('project.id'),
                 spider: spider.get('id'),
                 sample: sample.get('id')
+            }).then(() => {
+                if (redirect) {
+                    sample.set('new', true);
+                    const routing = this.get('routing');
+                    routing.transitionTo('projects.project.spider.sample', [sample], {}, true);
+                }
             });
-
-            if (redirect) {
-                sample.set('new', true);
-                const routing = this.get('routing');
-                routing.transitionTo('projects.project.spider.sample', [sample], {}, true);
-            }
         });
         return sample;
     },

--- a/portiaui/app/services/extracted-items.js
+++ b/portiaui/app/services/extracted-items.js
@@ -85,7 +85,7 @@ export default Ember.Service.extend({
             'links': data.links,
             'changes': data.changes,
             'type': data.type,
-            'changed_values': data.changed_values
+            'changed': data.changed
         });
     },
 

--- a/portiaui/app/services/saving-notification.js
+++ b/portiaui/app/services/saving-notification.js
@@ -1,16 +1,16 @@
 import Ember from 'ember';
+const { computed, inject: { service } } = Ember;
 
 export default Ember.Service.extend({
-    extractedItems: Ember.inject.service(),
+    extractedItems: service(),
 
     counter: 0,
     lastSaved: null,
 
-    isSaving: Ember.computed.bool('counter'),
+    isSaving: computed.bool('counter'),
 
     start() {
         this.get('extractedItems').activateExtraction();
-
         this.incrementProperty('counter');
     },
 

--- a/portiaui/app/services/web-socket.js
+++ b/portiaui/app/services/web-socket.js
@@ -173,7 +173,7 @@ export default Ember.Service.extend(Ember.Evented, {
             data._meta.id = shortGuid();
         }
         if(this.get('opened')) {
-            this.set('deferreds.' + data._meta.id, deferred);
+            this.set(`deferreds.${data._meta.id}`, deferred);
             this.send(data);
         } else {
             deferred.reject('Websocket is closed');

--- a/portiaui/app/styles/components/top-bar.scss
+++ b/portiaui/app/styles/components/top-bar.scss
@@ -1,5 +1,6 @@
 #top-bar {
     margin-bottom: 0;
+    z-index: 998;
 
     &:before,
     &:after {

--- a/portiaui/app/templates/application.hbs
+++ b/portiaui/app/templates/application.hbs
@@ -1,4 +1,5 @@
 <section id="window">
+    {{loading-slider isLoading=loading duration=200}}
     <nav id="top-bar" class="navbar navbar-default navbar-static-top">
         <div class="navbar-header navbar-left">
             {{partial 'branding'}}

--- a/portiaui/app/templates/components/extracted-items-status.hbs
+++ b/portiaui/app/templates/components/extracted-items-status.hbs
@@ -1,12 +1,7 @@
-{{#link-to 'projects.project.spider.options' bubbles=false}}
+{{#link-to changeInfo.path changeInfo.model bubbles=false}}
     {{#help-icon icon=icon placement='left'}}
         {{#if hasWarning}}
-            {{#if (eq type 'js')}}
-                Javascript is enabled for this sample and may not be needed.
-                Your spider may run faster if Javascript is not run on pages like this
-            {{else}}
-                Javascript is not enabled for this sample. It may extract more accurate data if it is enabled
-            {{/if}}
+            {{changeInfo.text}}
         {{else}}
             Your sample is correctly configured for extraction
         {{/if}}

--- a/portiaui/app/templates/components/list-item-link-crawling.hbs
+++ b/portiaui/app/templates/components/list-item-link-crawling.hbs
@@ -8,3 +8,6 @@
         {{/select.item}}
     {{/each}}
 {{/list-item-selectable}}
+{{#help-icon}}
+    {{linksToFollow.description}}
+{{/help-icon}}

--- a/portiaui/package.json
+++ b/portiaui/package.json
@@ -35,6 +35,7 @@
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-jshint": "^1.0.0",
+    "ember-cli-loading-slider": "^1.3.0",
     "ember-cli-qunit": "^1.4.0",
     "ember-cli-release": "^0.2.9",
     "ember-cli-sass": "^5.3.1",


### PR DESCRIPTION
Do not load extractors when reading annotations - it does it for every one
Use `strip_json` function instead of if s.endswith('.json'): s[:-len('.json')]
Load html into sample un websocket for extraction
Add callback function for save_html
Do not transition to sample while saving html when creating new sample
Load template_names from spider directory not from spider json
Allow users to annotate id and class attributes
Use `auto` link following by default
433 - Choose appropriate field type based on selected attribute
741 - Inform user when they have an unused required field in their schema
745 - Add help icon describing what crawl rules do
746 - Add loading indicator during loads and saves