### PR TITLE
Fix splash browser tab storing wrong html

### DIFF
--- a/portiaui/app/components/browser-iframe.js
+++ b/portiaui/app/components/browser-iframe.js
@@ -55,6 +55,7 @@ const BrowserIFrame = Ember.Component.extend({
         const ws = this.get('webSocket');
         ws.connect();
         ws.addCommand('loadStarted', this, this.msgLoadStarted);
+        ws.addCommand('loadFinished', this, this.msgMetadata);
         ws.addCommand('metadata', this, this.msgMetadata);
         ws.addCommand('load', this, this.msgLoad);
         ws.addCommand('cookies', this, this.msgCookies);
@@ -75,6 +76,7 @@ const BrowserIFrame = Ember.Component.extend({
     willDestroyElement() {
         const ws = this.get('webSocket');
         ws.removeCommand('loadStarted', this, this.msgLoadStarted);
+        ws.removeCommand('loadFinished', this, this.msgMetadata);
         ws.removeCommand('metadata', this, this.msgMetadata);
         ws.removeCommand('load', this, this.msgLoad);
         ws.removeCommand('cookies', this, this.msgCookies);

--- a/slyd/slyd/splash/commands.py
+++ b/slyd/slyd/splash/commands.py
@@ -215,7 +215,7 @@ class Commands(object):
 
     def close_tab(self):
         """Close virtual tab if it is open"""
-        if self.tab is not None:
+        if self.tab is not None and not self.tab._closing:
             self.tab.close()
             self.socket.factory[self.socket].tab = None
 

--- a/slyd/slyd/splash/ferry.py
+++ b/slyd/slyd/splash/ferry.py
@@ -3,6 +3,7 @@ from functools import partial
 import json
 import os
 import copy
+import re
 
 from six.moves.urllib_parse import urlparse
 
@@ -16,12 +17,12 @@ from twisted.python import log
 from scrapy.settings import Settings
 from scrapy.utils.serialize import ScrapyJSONEncoder
 from splash import defaults
-from splash.browser_tab import BrowserTab
+from splash.browser_tab import BrowserTab, skip_if_closing
 from splash.network_manager import SplashQNetworkAccessManager
 from splash.render_options import RenderOptions
 
 from slybot.spider import IblSpider
-from slyd.errors import BaseHTTPError
+from portia_api.errors import BaseHTTPError
 
 from django.db import close_old_connections
 
@@ -71,6 +72,7 @@ class PortiaNetworkManager(SplashQNetworkAccessManager):
                 self.tab.web_page.mainFrame().requestedUrl().toEncoded())
             if url == frame_url:
                 self._raw_html = ''
+                self._url = ''
                 reply.readyRead.connect(self._ready_read)
         except:
             log.err()
@@ -81,6 +83,20 @@ class PortiaNetworkManager(SplashQNetworkAccessManager):
         reply = self.sender()
         self._raw_html = (self._raw_html + six.binary_type(
             reply.peek(reply.bytesAvailable())))
+        self._url = six.text_type(reply.url().toString())
+
+
+class PortiaBrowserTab(BrowserTab):
+    @property
+    def url(self):
+        """ Current URL """
+        if self._closing:
+            return ''
+        return six.text_type(self.web_page.mainFrame().url().toString())
+
+    @skip_if_closing
+    def evaljs(self, *args, **kwargs):
+        return super(PortiaBrowserTab, self).evaljs(*args, **kwargs)
 
 
 class FerryWebSocketResource(WebSocketResource):
@@ -369,7 +385,7 @@ class FerryServerProtocol(WebSocketServerProtocol):
         data = {}
         data['uid'] = id(data)
 
-        self.factory[self].tab = BrowserTab(
+        self.factory[self].tab = PortiaBrowserTab(
             network_manager=manager,
             splash_proxy_factory=None,
             verbosity=0,
@@ -385,6 +401,7 @@ class FerryServerProtocol(WebSocketServerProtocol):
             cookiejar.put_client_cookies(meta['cookies'])
 
         main_frame.loadStarted.connect(self._on_load_started)
+        main_frame.loadFinished.connect(self._on_load_finished)
         self.js_api = PortiaJSApi(self)
         main_frame.javaScriptWindowObjectCleared.connect(
             self.populate_window_object
@@ -397,6 +414,12 @@ class FerryServerProtocol(WebSocketServerProtocol):
 
     def _on_load_started(self):
         self.sendMessage({'_command': 'loadStarted'})
+
+    def _on_load_finished(self):
+        if getattr(self.tab.network_manager, '_url', None) != self.tab.url:
+            page = self.tab.web_page
+            page.triggerAction(page.ReloadAndBypassCache, False)
+        self.sendMessage({'_command': 'loadFinished', 'url': self.tab.url})
 
     def populate_window_object(self):
         main_frame = self.tab.web_page.mainFrame()

--- a/slyd/slyd/splash/utils.py
+++ b/slyd/slyd/splash/utils.py
@@ -3,15 +3,10 @@ import six
 from scrapy.http import HtmlResponse, Request
 from scrapy.item import DictItem
 
-from slyd.html import descriptify
-from slyd.errors import BaseHTTPError
+from portia_api.errors import BaseHTTPError
 from slybot.baseurl import insert_base_url
 from slybot.utils import encode, decode
 _DEFAULT_VIEWPORT = '1240x680'
-
-
-def clean(html, url):
-    return insert_base_url(descriptify(html, url), url)
 
 
 def decoded_html(tab, type_=None):


### PR DESCRIPTION
If a user loaded a page, Then loaded a different page, then went back to the
initial page, then created a sample the html stored in the `original_body.html`
file may have been incorrect. This is caused by the html being stored during
`reply_read` phase of the network manager which is not called on a subsequent
page load due to caching. The solution used here is just to reload the page
if the html is incorrect, this is found through comparing the url in the frame
and in the network manager

Other Changes:
Send page metadata to the UI on page load finished
Do no evaljs or load page url if the tab is in a closing state