### PR TITLE
Allow default Data Format for project

### DIFF
--- a/portia_server/portia_api/resources/models.py
+++ b/portia_server/portia_api/resources/models.py
@@ -91,6 +91,7 @@ class ProjectSchema(SlydSchema):
 class SchemaSchema(SlydSchema):
     id = fields.Str(dump_only=True)
     name = fields.Str()
+    default = fields.Boolean()
     project = fields.Relationship(
         related_url='/api/projects/{project_id}',
         related_url_kwargs={'project_id': '<project_id>'},

--- a/portia_server/portia_api/resources/projects.py
+++ b/portia_server/portia_api/resources/projects.py
@@ -200,6 +200,7 @@ class ProjectRoute(ProjectDownloadMixin, BaseProjectRoute,
                 ],
                 'schemas': [
                     'name',
+                    'default',
                     'project',
                 ],
             },

--- a/portia_server/portia_api/resources/schemas.py
+++ b/portia_server/portia_api/resources/schemas.py
@@ -19,10 +19,20 @@ class SchemaRoute(BaseProjectModelRoute):
             'fields_map': {
                 'schemas': [
                     'name',
+                    'default',
                     'project',
                 ],
             }
         }
+
+    def update(self, *args, **kwargs):
+        # Reset default schema if current schema will be default
+        if self.data.get('data', {}).get('attributes', {}).get('default'):
+            for schema in self.get_collection():
+                if schema.default:
+                    schema.default = False
+                schema.save()
+        return super(SchemaRoute, self).update(*args, **kwargs)
 
     def destroy(self, *args, **kwargs):
         try:

--- a/portia_server/portia_api/resources/serializers.py
+++ b/portia_server/portia_api/resources/serializers.py
@@ -191,11 +191,14 @@ class SampleSerializer(JsonApiSerializer):
         sample = super(SampleSerializer, self).create(validated_data)
 
         project = sample.spider.project
-        schema_names = map(attrgetter('name'), project.schemas)
-        schema_name = unique_name(sample.name, schema_names)
-        schema = Schema(self.storage, id=AUTO_PK, name=schema_name,
-                        project=project, auto_created=True)
-        schema.save()
+        schemas = project.schemas
+        schema = next((s for s in schemas if s.default), None)
+        if schema is None:
+            schema_names = map(attrgetter('name'), schemas)
+            schema_name = unique_name(sample.name, schema_names)
+            schema = Schema(self.storage, id=AUTO_PK, name=schema_name,
+                            project=project, auto_created=True)
+            schema.save()
 
         item = Item(self.storage, id=AUTO_PK, sample=sample, schema=schema)
         item.save()

--- a/portia_server/portia_orm/models.py
+++ b/portia_server/portia_orm/models.py
@@ -60,6 +60,7 @@ class Schema(Model):
     id = String(primary_key=True)
     name = String(required=True)
     auto_created = Boolean(default=False)
+    default = Boolean(default=False)
     project = BelongsTo(Project, related_name='schemas', on_delete=CASCADE,
                         ignore_in_file=True)
     fields = HasMany('Field', related_name='schema', on_delete=CLEAR)
@@ -94,6 +95,8 @@ class Schema(Model):
     def remove_auto_created_false(self, data):
         if 'auto_created' in data and not data['auto_created']:
             del data['auto_created']
+        if 'default' in data and not data['default']:
+            del data['default']
         return data
 
     @post_dump(pass_many=True)

--- a/portiaui/app/components/icon-button.js
+++ b/portiaui/app/components/icon-button.js
@@ -8,6 +8,8 @@ export const ICON_CLASSES = {
     copy: 'fa fa-copy',
     'data-annotation': 'fa fa-hand-pointer-o',
     date: 'fa fa-calendar',
+    'default-add': 'fa fa-check-circle structure-list-publish',
+    'default-remove': 'fa fa-times-circle structure-list-discard',
     download: 'fa fa-download',
     publish: 'structure-list-publish fa fa-cloud-upload',
     edit: 'fa fa-pencil',

--- a/portiaui/app/components/project-structure-listing.js
+++ b/portiaui/app/components/project-structure-listing.js
@@ -113,6 +113,17 @@ export default Ember.Component.extend({
             this.get('dispatcher').removeSchema(schema);
         },
 
+        setSchemaDefault(schema) {
+            this.get('project.schemas').filterBy('default').forEach((s) => s.set('default', false));
+            schema.set('default', true);
+            schema.save();
+        },
+
+        removeSchemaDefault(schema) {
+            schema.set('default', false);
+            schema.save()
+        },
+
         saveSchema(schema) {
             schema.save();
         },

--- a/portiaui/app/models/schema.js
+++ b/portiaui/app/models/schema.js
@@ -3,6 +3,7 @@ import BaseModel from './base';
 
 export default BaseModel.extend({
     name: DS.attr('string'),
+    default: DS.attr('boolean'),
     project: DS.belongsTo(),
     fields: DS.hasMany(),
     items: DS.hasMany()

--- a/portiaui/app/templates/components/project-structure-listing.hbs
+++ b/portiaui/app/templates/components/project-structure-listing.hbs
@@ -130,19 +130,34 @@
             {{#each project.schemas as |schema|}}
                 {{#tree-list-item hide=(and currentSchema (not-eq schema currentSchema)) as |options|}}
                     {{#link-to 'projects.project.schema' schema}}
-                        {{indentation-spacer}}
+                        {{#if schema.default}}
+                            {{#help-icon icon='default-add' placement='right' classes='help-icon indentation-spacer'}}
+                                This Data Format will be used for new samples by default
+                            {{/help-icon}}
+                        {{else}}
+                            {{indentation-spacer}}
+                        {{/if}}
                         {{list-item-icon icon='schema'}}
                         {{list-item-editable value=(mut schema.name) editing=(mut schema.new) onChange=(action 'saveSchema' schema)}}
-                        {{#animation-container class="icon" setWidth=false setHeight=false}}
-                            {{#list-item-icon-menu icon='vertical-ellipsis' as |options|}}
-                                {{dropdown-delete
-                                  onDelete=(action 'removeSchema' schema)
-                                  text='Delete Schema'
-                                  disabled=(not (not schema.items.length))
-                                }}
-                            {{/list-item-icon-menu}}
-                        {{/animation-container}}
                     {{/link-to}}
+                    {{#animation-container class="icon" setWidth=false setHeight=false}}
+                        {{#list-item-icon-menu icon='vertical-ellipsis' as |options|}}
+                            {{#if schema.default}}
+                                <li {{action 'removeSchemaDefault' schema}}><a>
+                                {{list-item-icon class="icon" icon="default-remove"}}Remove as Default
+                                </a></li>
+                            {{else}}
+                                <li {{action 'setSchemaDefault' schema}}><a>
+                                {{list-item-icon class="icon" icon="default-add"}}Set as Default
+                                </a></li>
+                            {{/if}}
+                            {{dropdown-delete
+                              onDelete=(action 'removeSchema' schema)
+                              text='Delete Schema'
+                              disabled=(gt schema.items.length 0)
+                            }}
+                        {{/list-item-icon-menu}}
+                    {{/animation-container}}
                 {{/tree-list-item}}
             {{/each}}
         {{/if}}


### PR DESCRIPTION
Allows a user to set a single Data Format to be used by default when creating
a new sample. If a default Data Format is set no new Data Format will be
created when a new sample is created and the default Data Format will be used.
![popover](https://cloud.githubusercontent.com/assets/6472969/23551531/0b8be752-000f-11e7-8336-73c949227b04.png)
![dropdown](https://cloud.githubusercontent.com/assets/6472969/23551533/0e6f4a36-000f-11e7-9b13-bbb8727e0f8c.png)
![dropdown_set](https://cloud.githubusercontent.com/assets/6472969/23551536/10108a12-000f-11e7-9034-c15d60abba2e.png)
