### PR TITLE
Block urls if they fail to load

### DIFF
--- a/portiaui/app/components/browser-url-blocked.js
+++ b/portiaui/app/components/browser-url-blocked.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+    tagName: 'span',
+});

--- a/portiaui/app/components/browser-url-failing.js
+++ b/portiaui/app/components/browser-url-failing.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+const { inject: { service } } = Ember;
+
+export default Ember.Component.extend({
+    tagName: 'span',
+    browser: service(),
+
+    actions: {
+        reloadPage() {
+            this.get('browser').reload();
+        }
+    }
+});

--- a/portiaui/app/instance-initializers/error-handler.js
+++ b/portiaui/app/instance-initializers/error-handler.js
@@ -61,6 +61,8 @@ export function initialize(applicationInstance) {
             // Skip errors when operating on deleted
             Ember.Logger.debug(`Model Error: ${err.message}`);
             logErrorStack(err, Ember.Logger.debug);
+        } else if (err.fileName === 'websocket-browser-load') {
+            logErrorStack(err, Ember.Logger.debug);
         } else {
             logErrorStack(err);
             notificationManager.add({

--- a/portiaui/app/storages/page-loads.js
+++ b/portiaui/app/storages/page-loads.js
@@ -1,0 +1,5 @@
+import StorageObject from 'ember-local-storage/local/object';
+
+const Storage = StorageObject.extend();
+
+export default Storage;

--- a/portiaui/app/templates/components/browser-url-blocked.hbs
+++ b/portiaui/app/templates/components/browser-url-blocked.hbs
@@ -1,0 +1,1 @@
+Portia is having trouble loading this page at the moment. Try a different page or try again later.

--- a/portiaui/app/templates/components/browser-url-failing.hbs
+++ b/portiaui/app/templates/components/browser-url-failing.hbs
@@ -1,0 +1,1 @@
+Portia is currently having trouble loading this page would you like to <a class="alert-link" {{action 'reloadPage'}}>try again</a>?

--- a/portiaui/app/templates/components/browser-view-port.hbs
+++ b/portiaui/app/templates/components/browser-view-port.hbs
@@ -4,15 +4,20 @@
         {{yield (hash section="toolbar")}}
     </div>
 </div>
-<div class="browser-banner{{unless webSocket.closed ' hide'}}">
+<div class="browser-banner{{unless webSocket.showBanner ' hide'}}">
     {{#if webSocket.connecting}}
         Connecting ...
-    {{/if}}
-    {{#if webSocket.secondsUntilReconnect }}
-        Reconnecting to Portia server in {{webSocket.secondsUntilReconnect}} seconds.
+    {{else if webSocket.closed}}
+        {{#if webSocket.secondsUntilReconnect }}
+            Reconnecting to Portia server in {{webSocket.secondsUntilReconnect}} seconds.
+        {{else if websocket.reconnectMessage}}
+            {{websocket.reconnectMessage}}
+        {{/if}}
         {{#unless webSocket.reconnectImminent}}
             <a class="alert-link" {{action 'reconnectWebsocket'}}>Try Again</a>.
         {{/unless}}
+    {{else if webSocket.reconnectComponent}}
+        {{component webSocket.reconnectComponent}}
     {{/if}}
 </div>
 <div class="frame-container panel-body">

--- a/portiaui/vendor/tree-mirror.js
+++ b/portiaui/vendor/tree-mirror.js
@@ -224,6 +224,15 @@ var TreeMirrorClient = (function () {
         } else if(attr === "style"){
             obj[attr] = __portiaApi.processCss(value, node.baseURI);
             obj['data-portia-' + attr] = value;
+        } else if (attr === 'srcset' && tagName === 'IMG') {
+            var split_attr = value.split(',')
+            for (var i=0; i < split_attr.length; i++) {
+                split_attr[i] = __portiaApi.wrapUrl(
+                    split_attr[i].trim(),
+                    node.baseURI);
+            }
+            obj[attr] = split_attr.join(', ')
+            obj['data-portia-' + attr] = value;
         } else if (isUrlAttribute(tagName, attr)){
             obj[attr] = __portiaApi.wrapUrl(value, node.baseURI);
             obj['data-portia-' + attr] = value;

--- a/slyd/slyd/splash/ferry.py
+++ b/slyd/slyd/splash/ferry.py
@@ -19,9 +19,11 @@ from scrapy.utils.serialize import ScrapyJSONEncoder
 from splash import defaults
 from splash.browser_tab import BrowserTab, skip_if_closing
 from splash.network_manager import SplashQNetworkAccessManager
+from splash.qtutils import drop_request
 from splash.render_options import RenderOptions
 
 from slybot.spider import IblSpider
+from slybot.utils import decode
 from portia_api.errors import BaseHTTPError
 
 from django.conf import settings
@@ -47,6 +49,26 @@ txaio.use_twisted()
 
 _DEFAULT_USER_AGENT = ('Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 '
                        '(KHTML, like Gecko) Chrome/48.0.2564.82 Safari/537.36')
+IGNORED_TYPES = ('video/', 'audio/', 'application/ogg')
+MEDIA_EXTENSIONS = (
+    '.aac', '.avi', '.mid', '.mpeg', '.oga', '.ogv', '.ogx', '.swf',
+    '.wav', '.weba', '.webm', '.xul', '.3gp', '.3g2'
+)
+STORED_TYPES = ('text/html', 'text/xhtml', 'text/xml', 'text/plain',
+                'text/css', 'image/', 'application/font')
+STORED_EXTENSIONS = ('.jpg', 'jpeg', '.png', '.webp', '.gif', '.svg', '.css',
+                     '.xml', '.html', '.htm', '.xhtml', '.woff', '.woff2',
+                     '.ttf', '.otf', '.eot')
+
+
+def _is_xml(accepts):
+    if accepts.startswith('application/'):
+        has_xml = accepts.find('xml')
+        if has_xml > 0:
+            semicolon = accepts.find(';')
+            if semicolon < 0 or has_xml < semicolon:
+                return True
+    return False
 
 
 def wrap_callback(connection, callback, retries=0, **parsed):
@@ -221,6 +243,7 @@ class PortiaJSApi(QObject):
             self.call = task.deferLater(self.protocol.factory.reactor, 1,
                                         self.extract)
 
+
     def extract(self):
         commands = Commands({}, self.protocol, None)
         self.protocol.sendMessage(commands.metadata())
@@ -377,7 +400,7 @@ class FerryServerProtocol(WebSocketServerProtocol):
     def open_tab(self, meta=None):
         if meta is None:
             meta = {}
-        manager = PortiaNetworkManager(
+        manager = SplashQNetworkAccessManager(
             request_middlewares=[],
             response_middlewares=[],
             verbosity=defaults.VERBOSITY
@@ -395,6 +418,8 @@ class FerryServerProtocol(WebSocketServerProtocol):
             visible=True,
         )
         manager.tab = self.tab
+        self.tab.register_callback('on_request', self._configure_requests)
+        self.tab.register_callback('on_response', self._set_tab_html)
         main_frame = self.tab.web_page.mainFrame()
         cookiejar = PortiaCookieJar(self.tab.web_page, self)
         manager.cookiejar = cookiejar
@@ -422,15 +447,34 @@ class FerryServerProtocol(WebSocketServerProtocol):
         self.tab.initial_layout_completed = False
 
     def _on_load_finished(self):
-        if getattr(self.tab.network_manager, '_url', None) != self.tab.url:
+        if getattr(self.tab, '_raw_url', None) != self.tab.url:
             page = self.tab.web_page
             page.triggerAction(page.ReloadAndBypassCache, False)
         self.sendMessage({'_command': 'loadFinished', 'url': self.tab.url,
                           'id': getattr(self, 'load_id', None)})
 
+    def _configure_requests(self, request, operation, data):
+        if request.hasRawHeader('Accept'):
+            url = six.binary_type(request.url().toEncoded())
+            url_path = urlparse(url).path.lower()
+            accepts = str(request.rawHeader('Accept')).lower()
+            if (accepts.startswith(STORED_TYPES) or _is_xml(accepts) or
+                    url_path.endswith(STORED_EXTENSIONS)):
+                request.track_response_body = True
+            elif (accepts.startswith(IGNORED_TYPES) or
+                  url_path.endswith(MEDIA_EXTENSIONS)):
+                drop_request(request)
+
+    def _set_tab_html(self, reply, har, content):
+        url = six.binary_type(reply.url().toString())
+        if content is not None and url == self.tab.url:
+            self.tab._raw_html = decode(content)
+            self.tab._raw_url = url
+
     def _on_layout_completed(self):
-        self.populate_window_object()
-        self.tab.initial_layout_completed = True
+        if not getattr(self.tab, 'initial_layout_completed', False):
+            self.populate_window_object()
+            self.tab.initial_layout_completed = True
 
     def _on_javascript_window_cleared(self):
         if self.tab.initial_layout_completed:

--- a/slyd/slyd/splash/ferry.py
+++ b/slyd/slyd/splash/ferry.py
@@ -31,6 +31,7 @@ from storage import create_project_storage
 
 from portia_orm.models import Project
 from portia_orm.datastore import data_store_context
+from portia_orm.utils import short_guid
 from portia_api.utils.spiders import load_spider_data
 
 from .qtutils import QObject, pyqtSlot, QWebElement
@@ -415,14 +416,17 @@ class FerryServerProtocol(WebSocketServerProtocol):
         self.tab.loaded = False
 
     def _on_load_started(self):
-        self.sendMessage({'_command': 'loadStarted'})
+        self.load_id = short_guid()
+        self.sendMessage({'_command': 'loadStarted', 'id': self.load_id,
+                          'url': self.tab.url})
         self.tab.initial_layout_completed = False
 
     def _on_load_finished(self):
         if getattr(self.tab.network_manager, '_url', None) != self.tab.url:
             page = self.tab.web_page
             page.triggerAction(page.ReloadAndBypassCache, False)
-        self.sendMessage({'_command': 'loadFinished', 'url': self.tab.url})
+        self.sendMessage({'_command': 'loadFinished', 'url': self.tab.url,
+                          'id': getattr(self, 'load_id', None)})
 
     def _on_layout_completed(self):
         self.populate_window_object()

--- a/slyd/slyd/splash/utils.py
+++ b/slyd/slyd/splash/utils.py
@@ -4,7 +4,6 @@ from scrapy.http import HtmlResponse, Request
 from scrapy.item import DictItem
 
 from portia_api.errors import BaseHTTPError
-from slybot.baseurl import insert_base_url
 from slybot.utils import encode, decode
 _DEFAULT_VIEWPORT = '1240x680'
 
@@ -12,7 +11,7 @@ _DEFAULT_VIEWPORT = '1240x680'
 def decoded_html(tab, type_=None):
     if type_ == 'raw':
         stated_encoding = tab.evaljs('document.characterSet')
-        return decode(tab.network_manager._raw_html or tab.html(),
+        return decode(tab._raw_html or tab.html(),
                       default=stated_encoding)
     return tab.html()
 


### PR DESCRIPTION
If a url is consistently causing the websocket to lose connection with the server provide a message to the user telling them that the page they are loading is not supported and give them the chance to try again. If the page continues to fail block that url for an hour on the user's side.

Give user a message when they go offline that Portia will reconnect as soon as they come back online again
Store certain types of responses in the har log for access from the proxy endpoint
Get proxy endpoint to load from load from har log before using the http client to load data.