### PR TITLE
Add option to export code with xpath queries instead of css selectors

### DIFF
--- a/portia_server/portia_api/resources/projects.py
+++ b/portia_server/portia_api/resources/projects.py
@@ -26,6 +26,7 @@ class ProjectDownloadMixin(object):
         fmt = self.query.get('format', 'spec')
         version = self.query.get('version', None)
         branch = self.query.get('branch', None)
+        selector = self.query.get('selector') or 'css'
         spider_id = self.kwargs.get('spider_id', None)
         spiders = [spider_id] if spider_id is not None else None
         try:
@@ -41,7 +42,8 @@ class ProjectDownloadMixin(object):
                 raise JsonApiNotFoundError(str(e))
         archiver = CodeProjectArchiver if fmt == u'code' else ProjectArchiver
         try:
-            content = archiver(self.storage).archive(spiders)
+            content = archiver(self.storage).archive(
+                spiders, selector=selector)
         except IOError as e:
             raise JsonApiNotFoundError(str(e))
         return FileResponse('{}.zip'.format(self.project.name), content,

--- a/portia_server/portia_api/utils/download.py
+++ b/portia_server/portia_api/utils/download.py
@@ -48,7 +48,7 @@ class ProjectArchiver(object):
         if required_files is not None:
             self.required_files = required_files
 
-    def archive(self, spiders=None):
+    def archive(self, spiders=None, **kwargs):
         """
         Zip the contents or a subset of the contents in this project together
         """
@@ -212,7 +212,7 @@ class ProjectArchiver(object):
 
 
 class CodeProjectArchiver(ProjectArchiver):
-    def archive(self, spiders=None):
+    def archive(self, spiders=None, **kwargs):
 
         class ArchivingStorage(object):
             def __init__(self, storage):
@@ -238,7 +238,9 @@ class CodeProjectArchiver(ProjectArchiver):
         storage = ArchivingStorage(self.storage)
         schemas, extractors, spiders = load_project_data(storage)
         name = self._process_name()
-        return port_project(name, schemas, spiders, extractors)
+        selector = kwargs.get('selector') or 'css'
+        return port_project(name, schemas, spiders, extractors,
+                            selector=selector)
 
     def _process_name(self):
         try:

--- a/portia_server/requirements.txt
+++ b/portia_server/requirements.txt
@@ -11,4 +11,4 @@ MySQL-python==1.2.5
 requests==2.12.4
 toposort==1.5
 whitenoise==3.2.3
-portia2code==0.0.12
+portia2code==0.0.14


### PR DESCRIPTION
New `selector={css, xpath}` for use with `format=code` on the download endpoint