### PR TITLE
fix the default spider loader class.

### DIFF
--- a/portia_server/storage/projecttemplates.py
+++ b/portia_server/storage/projecttemplates.py
@@ -7,7 +7,7 @@ _SETTINGS_TEMPLATE = """\
 # Automatically created by: slyd
 import os
 
-SPIDER_MANAGER_CLASS = 'slybot.spidermanager.ZipfileSlybotSpiderManager'
+SPIDER_LOADER_CLASS = 'slybot.spidermanager.ZipfileSlybotSpiderManager'
 EXTENSIONS = {'slybot.closespider.SlybotCloseSpider': 1}
 ITEM_PIPELINES = {'slybot.dupefilter.DupeFilterPipeline': 1}
 SPIDER_MIDDLEWARES = {'slybot.spiderlets.SpiderletsMiddleware': 999}  # as close as possible to spider output

--- a/slybot/bin/portiacrawl
+++ b/slybot/bin/portiacrawl
@@ -34,12 +34,12 @@ def main():
     if project_specs.endswith(".zip"):
         command_spec.extend([
             "-s", "PROJECT_ZIPFILE=%s" % project_specs,
-            "-s", "SPIDER_MANAGER_CLASS=slybot.spidermanager.ZipfileSlybotSpiderManager",
+            "-s", "SPIDER_LOADER_CLASS=slybot.spidermanager.ZipfileSlybotSpiderManager",
         ])
     else:
         command_spec.extend([
             "-s", "PROJECT_DIR=%s" % project_specs,
-            "-s", "SPIDER_MANAGER_CLASS=slybot.spidermanager.SlybotSpiderManager",
+            "-s", "SPIDER_LOADER_CLASS=slybot.spidermanager.SlybotSpiderManager",
         ])
 
     if opts.logfile:

--- a/slybot/slybot/settings.py
+++ b/slybot/slybot/settings.py
@@ -1,5 +1,5 @@
 from __future__ import absolute_import
-SPIDER_MANAGER_CLASS = 'slybot.spidermanager.SlybotSpiderManager'
+SPIDER_LOADER_CLASS = 'slybot.spidermanager.SlybotSpiderManager'
 EXTENSIONS = {'slybot.closespider.SlybotCloseSpider': 1}
 ITEM_PIPELINES = {
     'slybot.dupefilter.DupeFilterPipeline': 1,


### PR DESCRIPTION
Hi all:
    Thanks for awesome work, since the scrapy version in portia has deprecated the option SPIDER_MANAGER_CLASS, we should use the latest version .