### PR TITLE
Install wget during prepare_install function

### DIFF
--- a/docker/provision.sh
+++ b/docker/provision.sh
@@ -77,6 +77,7 @@ prepare_install () {
     apt-get update
     apt-get install -y --no-install-recommends \
         curl \
+        wget \
         software-properties-common \
         apt-transport-https \
         python3-software-properties


### PR DESCRIPTION
On docker-compose up, several parts of the installation procedure fail due to wget not being available. It should be installed at this stage of the docker build.