### PR TITLE
small error on the docker command

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,7 +14,7 @@ You can run Portia with the command below::
 
 Or with docker-compose by running::
 
-    docker compose up
+    docker-compose up
 
 Portia will now be running on port 9001 and you can access it at ``http://localhost:9001``.
 Projects will be stored in the project folder that you mount to docker.


### PR DESCRIPTION
I wanted to carry out your command: docker compose up
my terminal returned an error it works with the command suite: docker-composes up

I'm on mac os catalina