### PR TITLE
Correct typo in docker setup docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -26,8 +26,8 @@ To extract data using portia you can run your spider with::
 
 After the crawl finishes you will find your extracted data in the the `OUTPUT_FOLDER`
 
-.. note:: *<PROJECT_FOLDER>* and *<OUTPUT_FOLDER>* are just paths on your system where your projects and extracted data are stored.
-.. warning:: For Windows the *<PROJECT_FOLDER>* path must be of the form */<DRIVE_LETTER/<PATH>*. For example */C/Users/UserName/Documents/PortiaProjects*
+.. note:: *<PROJECTS_FOLDER>* and *<OUTPUT_FOLDER>* are just paths on your system where your projects and extracted data are stored.
+.. warning:: For Windows the *<PROJECTS_FOLDER>* path must be of the form */<DRIVE_LETTER/<PATH>*. For example */C/Users/UserName/Documents/PortiaProjects*
 
 
 Vagrant


### PR DESCRIPTION
Minor typo in docs - name of environment variable used in documentation info box (PROJECT_FOLDER)
didn't match the actual name used in the example shell commands (PROJECTS_FOLDER)