### PR TITLE
fix(sec): upgrade scrapy-splash to 0.8.0

### DIFF
--- a/slybot/requirements.txt
+++ b/slybot/requirements.txt
@@ -8,6 +8,6 @@ dateparser==0.7.1
 python-dateutil==2.8.0
 jsonschema==2.6.0
 six==1.12.0
-scrapy-splash==0.7.2
+scrapy-splash==0.8.0
 page_finder==0.1.8
 chardet==3.0.4


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in scrapy-splash 0.7.2
- [CVE-2021-41124](https://www.oscs1024.com/hd/CVE-2021-41124)


### What did I do？
Upgrade scrapy-splash from 0.7.2 to 0.8.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS