### PR TITLE
Updated location of projects in the running spiders section of docs

### DIFF
--- a/docs/spiders.rst
+++ b/docs/spiders.rst
@@ -50,7 +50,7 @@ The ``Configure url patterns`` option lets you set follow and exclude patterns a
 Running a spider
 ================
 
-Portia will save your projects in ``slyd/data/projects``. You can use ``portiacrawl`` to run a spider::
+Portia will save your projects in ``app/data/projects``. You can use ``portiacrawl`` to run a spider::
 
     portiacrawl PROJECT_PATH SPIDER_NAME
 


### PR DESCRIPTION
## Issue 

Running this project on docker on 17-March-2023 14:54 IST, couldn't find neither the files nor the path where the projects are stored. It quite a while of manually search to realize that the location in the documentation is either not updated or mistaken. Do fix this. 

## Actual location of the projects

![screenshot 1](https://i.imgur.com/OOMHJE7.png)

```
# pwd
/app/data/projects
# ls -lah
total 24K
drwxr-xr-x 1 root root 4.0K Mar 17 07:31 .
drwxr-xr-x 1 root root 4.0K Jul 10  2019 ..
-rw-r--r-- 1 root root    0 Feb 27  2017 .gitkeep
drwxr-xr-x 3 root root 4.0K Mar 17 07:31 Based Cooking
drwxr-xr-x 3 root root 4.0K Mar 17 07:22 Dos Project
drwxr-xr-x 3 root root 4.0K Mar 17 07:12 Uno Project
# 
```

## Location according to the docs

![screenshot 2](https://i.imgur.com/uuLr5V2.png)

```
# pwd
/app/slyd
# ls -lah
total 60K
drwxr-xr-x 1 root root 4.0K Jul 10  2019 .
drwxr-xr-x 1 root root 4.0K Jul 10  2019 ..
-rw-r--r-- 1 root root  204 Feb 10  2017 .gitignore
-rw-r--r-- 1 root root  590 Feb 10  2017 .jshintrc
-rw-r--r-- 1 root root 4.1K Feb 10  2017 README.md
drwxr-xr-x 2 root root 4.0K Jul 10  2019 bin
-rw-r--r-- 1 root root  277 Jun 18  2019 requirements.txt
-rw-r--r-- 1 root root  915 Feb 10  2017 setup.py
lrwxrwxrwx 1 root root    9 Jul 10  2019 slybot -> ../slybot
drwxr-xr-x 1 root root 4.0K Mar 17 07:12 slyd
drwxr-xr-x 2 root root 4.0K Jul 10  2019 slyd.egg-info
drwxr-xr-x 3 root root 4.0K Jul 10  2019 twisted
# cd slyd
# pwd
/app/slyd/slyd
# ls -lah
total 84K
drwxr-xr-x 1 root root 4.0K Mar 17 07:12 .
drwxr-xr-x 1 root root 4.0K Jul 10  2019 ..
-rw-r--r-- 1 root root    0 Feb 10  2017 __init__.py
drwxr-xr-x 2 root root 4.0K Mar 17 07:12 __pycache__
-rw-r--r-- 1 root root  470 Feb 10  2017 authmanager.py
-rw-r--r-- 1 root root  623 Feb 10  2017 dummyauth.py
-rw-r--r-- 1 root root  730 Feb 10  2017 errors.py
drwxr-xr-x 2 root root 4.0K Jul 10  2019 gitstorage
-rw-r--r-- 1 root root 4.3K Jun 18  2019 html_utils.py
-rw-r--r-- 1 root root 4.6K Feb 10  2017 projects.py
-rw-r--r-- 1 root root 5.7K Jun 18  2019 projectspec.py
-rw-r--r-- 1 root root 2.1K Feb 10  2017 resource.py
-rw-r--r-- 1 root root 2.0K Feb 10  2017 server.py
drwxr-xr-x 1 root root 4.0K Mar 17 07:12 settings
-rw-r--r-- 1 root root 1.4K Feb 10  2017 specmanager.py
drwxr-xr-x 1 root root 4.0K Mar 17 07:12 splash
-rw-r--r-- 1 root root 3.0K Mar 27  2018 tap.py
# 
```