### PR TITLE
fix(sec): upgrade autobahn to 20.12.3

### DIFF
--- a/slyd/requirements.txt
+++ b/slyd/requirements.txt
@@ -3,7 +3,7 @@ twisted==19.2.1
 pyOpenSSL==17.5.0
 service_identity==18.1.0
 requests>=2.20.0
-autobahn==18.3.1
+autobahn==20.12.3
 six==1.12.0
 chardet==3.0.4
 parse==1.8.2


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in autobahn 18.3.1
- [CVE-2020-35678](https://www.oscs1024.com/hd/CVE-2020-35678)


### What did I do？
Upgrade autobahn from 18.3.1 to 20.12.3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS